### PR TITLE
fix: extended token required for cross repo api access

### DIFF
--- a/.github/workflows/refresh-profile.yml
+++ b/.github/workflows/refresh-profile.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   refresh:

--- a/.github/workflows/refresh-profile.yml
+++ b/.github/workflows/refresh-profile.yml
@@ -26,12 +26,12 @@ jobs:
 
       - name: Update README
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.SCORE_BOT_PAT }}
         run: uv run generate-profile-readme
 
       - name: Collect metrics
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.SCORE_BOT_PAT }}
         run: uv run python scripts/collect_metrics.py
 
       - name: Create Pull Request


### PR DESCRIPTION
It seems GITHUB_TOKEN does not allow cross repo read access to some APIs, specifically custom properties are members-only and not public.