### PR TITLE
feat: add SCORE governance core contracts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+You are operating inside the SCORE governance overlay.
+
+This file is runtime-specific glue.
+Canonical, runtime-neutral policy should live in AGENTS.md.
+
+This repository intentionally keeps only SCORE-specific governance contracts and lightweight maintenance rules.
+Generic workflow execution (for example Spec Kit, OpenSpec, BMAD, or custom runtime behavior) is inherited externally by adopter repositories.
+
+## Responsibilities
+
+1. Preserve issue-first traceability.
+2. Preserve SCORE-specific contracts:
+   - `.github/references/repo-manifest.schema.json`
+   - `.github/references/agent-card.schema.json`
+   - `.github/score/repo-manifest.json`
+3. Keep maintenance burden low by avoiding broad framework content in this repo.
+
+## Scope
+
+- Keep local content focused on SCORE-specific policy and schema contracts.
+- Avoid embedding large generic agent/prompt catalogs.
+- Prefer placeholders for runtime-specific naming:
+  - `<ASSISTANT_INSTRUCTIONS_FILE>`
+  - `<AI_ASSISTANT_NAME>`
+  - `<AI_REVIEW_BOT>`
+
+## Artifact Rules
+
+- Use issue-scoped folders for work artifacts:
+  - `.stage/ISSUE-<number>/...`
+- Never create anonymous stage artifacts at repository root.
+
+## SDLC Progress Block
+
+When status tracking is needed, use this block:
+
+### SDLC Progress -- <ISSUE-ID>
+- [ ] PLAN (Roadmap) -- Not Started (or Skipped)
+- [ ] PLAN (Tech Analysis) -- Not Started (or Skipped)
+- [ ] PLAN (Requirements) -- Not Started
+- [ ] SETUP -- Not Started (or Skipped)
+- [ ] CODE Phase -- Not Started
+- [ ] BUILD Phase -- Not Started
+- [ ] TEST Phase -- Not Started
+- [ ] RELEASE Phase -- Not Started
+
+Notes:
+- Roadmap planning is optional.
+- Most single issues go directly to requirements and implementation.
+
+## Governance Rules
+
+- Keep policy files concise and deterministic.
+- Keep generated or inherited framework artifacts outside this repository, or produce them from a renderer in adopter repos.
+- Run markdown hygiene checks before merge.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,8 @@ Generic workflow execution (for example Spec Kit, OpenSpec, BMAD, or custom runt
    - `.github/score/repo-manifest.json`
 3. Keep maintenance burden low by avoiding broad framework content in this repo.
 
+Terminology note: `.github/references/agent-card.schema.json` defines a SCORE work/handoff artifact, not an A2A service-discovery AgentCard.
+
 ## Scope
 
 - Keep local content focused on SCORE-specific policy and schema contracts.

--- a/.github/references/agent-card.schema.json
+++ b/.github/references/agent-card.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://score.dev/schemas/agent-card.schema.json",
+  "title": "SCORE Agent Card",
+  "description": "Structured handoff artifact exchanged between agents and tools for one issue-scoped work item.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "issue_id",
+    "repository",
+    "goal",
+    "status",
+    "summary",
+    "validation",
+    "next_action"
+  ],
+  "properties": {
+    "version": {
+      "const": 1
+    },
+    "issue_id": {
+      "type": "string",
+      "pattern": "^(ISSUE-[0-9]+|POC-[0-9]{8}-[0-9]{4})$"
+    },
+    "repository": {
+      "type": "string",
+      "minLength": 1
+    },
+    "branch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "goal": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "in_progress",
+        "blocked",
+        "ready_for_handoff",
+        "completed"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/note"
+      },
+      "default": []
+    },
+    "open_questions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "touched_files": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true,
+      "default": []
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "not_run",
+            "passed",
+            "failed"
+          ]
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/commandResult"
+          },
+          "default": []
+        }
+      }
+    },
+    "trajectory": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/note"
+      },
+      "default": []
+    },
+    "next_action": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "$defs": {
+    "note": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "detail"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "commandResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "status"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "passed",
+            "failed"
+          ]
+        },
+        "detail": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/.github/references/agent-card.schema.json
+++ b/.github/references/agent-card.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://score.dev/schemas/agent-card.schema.json",
-  "title": "SCORE Agent Card",
-  "description": "Structured handoff artifact exchanged between agents and tools for one issue-scoped work item.",
+  "title": "SCORE Work Card (Agent Handoff)",
+  "description": "Structured handoff artifact exchanged between agents and tools for one issue-scoped work item. This schema is a work/handoff artifact and is not the A2A service-discovery AgentCard.",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/.github/references/repo-manifest.schema.json
+++ b/.github/references/repo-manifest.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://score.dev/schemas/repo-manifest.schema.json",
+  "title": "SCORE Repo Manifest",
+  "description": "Minimal federated harness contract for a SCORE repository.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "repository",
+    "bootstrap",
+    "execution",
+    "mcp"
+  ],
+  "properties": {
+    "version": {
+      "const": 1
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "language",
+        "visibility"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "language": {
+          "type": "string",
+          "enum": [
+            "python",
+            "go",
+            "rust",
+            "cpp",
+            "typescript",
+            "mixed",
+            "other"
+          ]
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "public",
+            "internal",
+            "private"
+          ]
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true,
+          "default": []
+        }
+      }
+    },
+    "bootstrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_version"
+      ],
+      "properties": {
+        "contract_version": {
+          "type": "string",
+          "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "template_version": {
+          "type": "string",
+          "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+        }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "build",
+        "test",
+        "lint"
+      ],
+      "properties": {
+        "build": {
+          "$ref": "#/$defs/commandSpec"
+        },
+        "test": {
+          "$ref": "#/$defs/commandSpec"
+        },
+        "lint": {
+          "$ref": "#/$defs/commandSpec"
+        },
+        "typecheck": {
+          "$ref": "#/$defs/commandSpec"
+        }
+      }
+    },
+    "mcp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "server_name",
+        "tools"
+      ],
+      "properties": {
+        "server_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "build",
+              "test",
+              "lint",
+              "typecheck",
+              "search"
+            ]
+          },
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      }
+    }
+  },
+  "$defs": {
+    "commandSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "working_directory": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/.github/references/repo-manifest.schema.json
+++ b/.github/references/repo-manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://score.dev/schemas/repo-manifest.schema.json",
+  "$id": "https://eclipse-score.github.io/schemas/repo-manifest.schema.json",
   "title": "SCORE Repo Manifest",
   "description": "Minimal federated harness contract for a SCORE repository.",
   "type": "object",
@@ -9,8 +9,7 @@
     "version",
     "repository",
     "bootstrap",
-    "execution",
-    "mcp"
+    "execution"
   ],
   "properties": {
     "version": {

--- a/.github/score/repo-manifest.json
+++ b/.github/score/repo-manifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../references/repo-manifest.schema.json",
   "version": 1,
   "repository": {
     "name": "score_github",

--- a/.github/score/repo-manifest.json
+++ b/.github/score/repo-manifest.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "repository": {
+    "name": "score_github",
+    "language": "python",
+    "visibility": "public",
+    "tags": [
+      "bootstrap",
+      "github-profile"
+    ]
+  },
+  "bootstrap": {
+    "contract_version": "v0.1.0",
+    "template_version": "v0.1.0"
+  },
+  "execution": {
+    "build": {
+      "command": "uv build"
+    },
+    "test": {
+      "command": "uv run pytest"
+    },
+    "lint": {
+      "command": "uv run ruff check src tests scripts"
+    },
+    "typecheck": {
+      "command": "uv run basedpyright src tests scripts"
+    }
+  },
+  "mcp": {
+    "server_name": "score-repo-tools",
+    "tools": [
+      "build",
+      "test",
+      "lint",
+      "typecheck"
+    ]
+  }
+}


### PR DESCRIPTION
## Scope

This PR introduces the SCORE governance core contracts and runtime glue.

## Why

Extracted from oversized PR #51 to unblock focused review on the core governance surface.

## Out of scope

- shared instruction pack
- copier template distribution
- markdown hygiene and docs updates

## Validation

- one focused branch/commit slice for the governance core

## Merge Order

1. #54 (core contracts)
2. #55 (instruction pack)
3. #56 (copier template)
4. #57 (docs and hygiene)

This PR is intended to merge first.

## Relationship to original PR

This PR is part of the split of oversized PR #51.