### PR TITLE
feat: add shared SCORE coding instructions

### DIFF
--- a/.github/instructions/clean-code.instructions.md
+++ b/.github/instructions/clean-code.instructions.md
@@ -1,0 +1,93 @@
+---
+applyTo: '**'
+---
+
+# Clean Code Guidelines (All Languages)
+
+## Goal
+Code is *extremely readable*, composed of *very small and focused* methods/functions, and avoids all code smells.
+
+## General Principles
+- Code is for **humans first**, computers second
+- Express intent clearly -- self-explanatory names for variables, methods, classes
+- Prefer self-documenting code; comments as last resort
+- **Small is beautiful** -- small, focused methods and classes
+- Duplication is a bad sign -- extract and reuse
+- KISS -- reduce complexity as much as possible
+- YAGNI -- avoid over-engineering
+- Boy Scout Rule -- leave the codebase cleaner than you found it
+- Tell, Don't Ask -- promote loose coupling
+- Be Consistent -- follow existing conventions
+- Encapsulate boundary conditions in one place
+- Avoid negative conditionals
+- Use dependency injection
+
+## SOLID Principles
+- **SRP**: Each method/class does one thing only
+- **OCP**: Open for extension, closed for modification
+- **LSP**: Subtypes substitutable for base types
+- **ISP**: Small, focused interfaces
+- **DIP**: Depend on abstractions, not concretions
+
+## Code Smells to Remove
+Long Method, Large Class, Primitive Obsession, Long Parameter List (max 3), Data Clumps, Switch Statements, Temporary Field, Divergent Change, Shotgun Surgery, Duplicated Code, Dead Code, Feature Envy, Middle Man, Magic Numbers (replace with named constants).
+
+## Class Design
+- Small: max ~7 fields, ~3-5 public methods
+- Single clear purpose aligned with domain
+- Domain-focused naming (e.g. `PolicyRenewalService`, not `HelperUtil`)
+- Encapsulation -- hide internal structure
+- Prefer immutability, composition over inheritance
+- Follow Law of Demeter
+- Prefer value objects over primitives
+- Avoid God objects and util classes
+
+## Method Design
+- Ideal length: ~3 lines, rarely more than 5
+- Single atomic step of logic
+- Names describe *what* not *how*
+- No side effects
+- Use guard clauses / early returns
+- Avoid nested ifs/loops
+- No flag arguments -- split into separate methods
+- Extract complex predicates into named boolean methods
+
+## Test Design
+- Small, specific, isolated, fast, independent, repeatable
+- Arrange-Act-Assert format
+- Max 3 assertions per test
+- Always test new public behavior
+- At least one negative test per API
+- Avoid duplicated test data -- extract to class level
+
+## Naming
+- Descriptive and unambiguous
+- Methods: verbs. Classes: nouns. Variables: clear names
+- Pronounceable, searchable, no encodings
+
+## Comments
+- Explain *why*, not *what*
+- Document assumptions, invariants, edge cases
+- Never comment out code -- just remove it
+
+## Error Handling
+- Use domain-specific custom exceptions
+- Handle exceptions gracefully; never swallow them
+- Externalize user-facing messages
+- Maintain ErrorCode mapping
+
+## Security
+- No hardcoded secrets, URLs, or sensitive info
+- All sensitive config resolved via environment or config server
+- PII protection: data masking, tokenization
+
+## Performance
+- Avoid premature micro-optimizations unless profiled
+- Batch operations in single transactions
+- Refactor nested loops into indexed maps (O(n+m))
+
+## API Design
+- RESTful conventions with domain-driven design
+- Plural noun resources: `/v1/templates`
+- Accept filtering & expansion parameters
+- Consistent resource naming

--- a/.github/instructions/clean-code.instructions.md
+++ b/.github/instructions/clean-code.instructions.md
@@ -2,92 +2,64 @@
 applyTo: '**'
 ---
 
-# Clean Code Guidelines (All Languages)
+# Clean Code — Eclipse S-CORE
 
-## Goal
-Code is *extremely readable*, composed of *very small and focused* methods/functions, and avoids all code smells.
+## Principles
 
-## General Principles
-- Code is for **humans first**, computers second
-- Express intent clearly -- self-explanatory names for variables, methods, classes
-- Prefer self-documenting code; comments as last resort
-- **Small is beautiful** -- small, focused methods and classes
-- Duplication is a bad sign -- extract and reuse
-- KISS -- reduce complexity as much as possible
-- YAGNI -- avoid over-engineering
-- Boy Scout Rule -- leave the codebase cleaner than you found it
-- Tell, Don't Ask -- promote loose coupling
-- Be Consistent -- follow existing conventions
-- Encapsulate boundary conditions in one place
-- Avoid negative conditionals
-- Use dependency injection
-
-## SOLID Principles
-- **SRP**: Each method/class does one thing only
-- **OCP**: Open for extension, closed for modification
-- **LSP**: Subtypes substitutable for base types
-- **ISP**: Small, focused interfaces
-- **DIP**: Depend on abstractions, not concretions
-
-## Code Smells to Remove
-Long Method, Large Class, Primitive Obsession, Long Parameter List (max 3), Data Clumps, Switch Statements, Temporary Field, Divergent Change, Shotgun Surgery, Duplicated Code, Dead Code, Feature Envy, Middle Man, Magic Numbers (replace with named constants).
-
-## Class Design
-- Small: max ~7 fields, ~3-5 public methods
-- Single clear purpose aligned with domain
-- Domain-focused naming (e.g. `PolicyRenewalService`, not `HelperUtil`)
-- Encapsulation -- hide internal structure
-- Prefer immutability, composition over inheritance
-- Follow Law of Demeter
-- Prefer value objects over primitives
-- Avoid God objects and util classes
-
-## Method Design
-- Ideal length: ~3 lines, rarely more than 5
-- Single atomic step of logic
-- Names describe *what* not *how*
-- No side effects
-- Use guard clauses / early returns
-- Avoid nested ifs/loops
-- No flag arguments -- split into separate methods
-- Extract complex predicates into named boolean methods
-
-## Test Design
-- Small, specific, isolated, fast, independent, repeatable
-- Arrange-Act-Assert format
-- Max 3 assertions per test
-- Always test new public behavior
-- At least one negative test per API
-- Avoid duplicated test data -- extract to class level
+- Code is for humans first — self-explanatory names, clear intent
+- Small and focused: functions do one thing, files have one responsibility
+- No duplication — extract and reuse
+- KISS — reduce complexity; prefer straightforward solutions
+- YAGNI — implement only what is needed now
+- Boy Scout Rule — leave code cleaner than you found it
+- Follow existing conventions in the file/module you are editing
 
 ## Naming
+
 - Descriptive and unambiguous
-- Methods: verbs. Classes: nouns. Variables: clear names
-- Pronounceable, searchable, no encodings
+- Functions: verbs (`parse_manifest`, `validate_input`, `send_message`)
+- Types/classes: nouns (`MessageBuffer`, `ConfigEntry`, `TransportLayer`)
+- Constants: `UPPER_SNAKE_CASE`
+- No abbreviations unless universally understood in the domain (e.g. `ECU`, `CAN`, `SPI`)
+
+## Functions
+
+- Ideal: 5–15 lines, max 50
+- Single responsibility — one logical step per function
+- Max 3–4 parameters; group related params into a struct/dataclass
+- No flag arguments — split into separate functions
+- Use early returns / guard clauses to avoid deep nesting
+- Max 3 levels of nesting
 
 ## Comments
+
 - Explain *why*, not *what*
-- Document assumptions, invariants, edge cases
-- Never comment out code -- just remove it
+- Document assumptions, invariants, safety constraints
+- Never comment out code — remove it (git preserves history)
+- Public APIs must have doc comments (Doxygen for C++, `///` for Rust, docstrings for Python)
 
 ## Error Handling
-- Use domain-specific custom exceptions
-- Handle exceptions gracefully; never swallow them
-- Externalize user-facing messages
-- Maintain ErrorCode mapping
 
-## Security
-- No hardcoded secrets, URLs, or sensitive info
-- All sensitive config resolved via environment or config server
-- PII protection: data masking, tokenization
+- Handle errors explicitly — never silently ignore
+- Use the language's idiomatic error mechanism:
+  - C++: `std::expected`, error codes, or exceptions per module convention
+  - Rust: `Result<T, E>` — propagate with `?`, no `.unwrap()` in production code
+  - Python: specific exception types, never bare `except:`
+- Log errors with sufficient context for diagnosis
+- Fail fast at system boundaries
 
-## Performance
-- Avoid premature micro-optimizations unless profiled
-- Batch operations in single transactions
-- Refactor nested loops into indexed maps (O(n+m))
+## Dependencies
 
-## API Design
-- RESTful conventions with domain-driven design
-- Plural noun resources: `/v1/templates`
-- Accept filtering & expansion parameters
-- Consistent resource naming
+- Prefer standard library over third-party
+- Every dependency is a supply-chain risk — justify additions
+- All deps managed via Bazel (`MODULE.bazel`) or `pyproject.toml`
+
+## Code Smells to Fix
+
+- Long functions (>50 lines)
+- Deep nesting (>3 levels)
+- Duplicated logic
+- Dead code
+- Magic numbers (replace with named constants)
+- God objects / classes doing too many things
+- Mutable shared state without synchronization

--- a/.github/instructions/coding-style.instructions.md
+++ b/.github/instructions/coding-style.instructions.md
@@ -1,0 +1,65 @@
+---
+applyTo: '**'
+---
+
+# Coding Style
+
+## Immutability (CRITICAL)
+
+ALWAYS create new objects, NEVER mutate existing ones:
+- Return new instances rather than modifying in place
+- Use spread operators, `List.copyOf()`, `Map.copyOf()`, or equivalent
+- Mark fields `final` / `readonly` / `const` by default
+
+Rationale: Immutable data prevents hidden side effects, makes debugging easier, and enables safe concurrency.
+
+## File Organization
+
+MANY SMALL FILES > FEW LARGE FILES:
+- High cohesion, low coupling
+- 200-400 lines typical, 800 max
+- Extract utilities from large modules
+- Organize by feature/domain, not by type
+
+## Function Size
+
+- Ideal: 3-10 lines, rarely more than 20
+- Max: 50 lines — split if exceeded
+- Single atomic step of logic per function
+- No flag arguments — split into separate functions
+
+## Nesting
+
+- Max 4 levels of nesting
+- Use guard clauses and early returns to flatten
+- Extract complex predicates into named boolean methods
+- Extract inner loops into helper functions
+
+## Error Handling
+
+ALWAYS handle errors comprehensively:
+- Handle errors explicitly at every level
+- Provide user-friendly error messages in UI-facing code
+- Log detailed error context on the server side
+- Never silently swallow errors
+
+## Input Validation
+
+ALWAYS validate at system boundaries:
+- Validate all user input before processing
+- Use schema-based validation where available
+- Fail fast with clear error messages
+- Never trust external data (API responses, user input, file content)
+
+## Code Quality Checklist
+
+Before marking work complete:
+- [ ] Code is readable and well-named
+- [ ] Functions are small (<50 lines)
+- [ ] Files are focused (<800 lines)
+- [ ] No deep nesting (>4 levels)
+- [ ] Proper error handling at every level
+- [ ] No hardcoded values (use constants or config)
+- [ ] No mutation (immutable patterns used)
+- [ ] No `console.log` / `System.out.println` in production code
+- [ ] No TODO/FIXME without a linked issue

--- a/.github/instructions/coding-style.instructions.md
+++ b/.github/instructions/coding-style.instructions.md
@@ -2,64 +2,46 @@
 applyTo: '**'
 ---
 
-# Coding Style
+# Coding Style — Eclipse S-CORE
 
-## Immutability (CRITICAL)
+## C++
 
-ALWAYS create new objects, NEVER mutate existing ones:
-- Return new instances rather than modifying in place
-- Use spread operators, `List.copyOf()`, `Map.copyOf()`, or equivalent
-- Mark fields `final` / `readonly` / `const` by default
+- Follow the project's clang-tidy configuration from `score_cpp_policies`
+- Use `const` by default for variables, parameters, and member functions
+- Prefer value semantics; avoid raw pointers — use `std::unique_ptr`, `std::shared_ptr`
+- Prefer `std::string_view`, `std::span` for non-owning references
+- Use `std::optional` for values that may be absent
+- Use `std::expected` or project error types instead of exceptions where module convention requires it
+- No C-style casts — use `static_cast`, `dynamic_cast`, `reinterpret_cast`
+- Header includes: project headers first, then third-party, then standard library
+- Use include guards or `#pragma once` per project convention
+- Avoid macros; use `constexpr`, templates, or inline functions instead
+- No `using namespace std;` in headers
 
-Rationale: Immutable data prevents hidden side effects, makes debugging easier, and enables safe concurrency.
+## Rust
 
-## File Organization
+- Follow the project's Clippy configuration from `score_rust_policies`
+- Strict policy (`clippy/strict/clippy.toml`) for safety-critical code: no `panic!`, `unwrap()`, `expect()`
+- Relaxed policy (`clippy/relaxed/clippy.toml`) for tooling and tests only
+- Prefer `&str` over `String` for function parameters where ownership is not needed
+- Use `Result<T, E>` for all fallible operations — propagate with `?`
+- Derive traits (`Debug`, `Clone`, `PartialEq`) where appropriate
+- Group imports: `std`, external crates, crate-internal — separated by blank lines
+- Use `#[must_use]` on functions where ignoring the return value is likely a bug
 
-MANY SMALL FILES > FEW LARGE FILES:
-- High cohesion, low coupling
-- 200-400 lines typical, 800 max
-- Extract utilities from large modules
-- Organize by feature/domain, not by type
+## Python
 
-## Function Size
+- Format with `ruff format`; lint with `ruff check`
+- Type-check with `basedpyright`
+- `snake_case` for functions/variables, `CapWords` for classes
+- Type hints on all public functions
+- Imports: standard library, third-party, local — separated by blank lines
+- Absolute imports only; no wildcard imports
 
-- Ideal: 3-10 lines, rarely more than 20
-- Max: 50 lines — split if exceeded
-- Single atomic step of logic per function
-- No flag arguments — split into separate functions
+## General
 
-## Nesting
-
-- Max 4 levels of nesting
-- Use guard clauses and early returns to flatten
-- Extract complex predicates into named boolean methods
-- Extract inner loops into helper functions
-
-## Error Handling
-
-ALWAYS handle errors comprehensively:
-- Handle errors explicitly at every level
-- Provide user-friendly error messages in UI-facing code
-- Log detailed error context on the server side
-- Never silently swallow errors
-
-## Input Validation
-
-ALWAYS validate at system boundaries:
-- Validate all user input before processing
-- Use schema-based validation where available
-- Fail fast with clear error messages
-- Never trust external data (API responses, user input, file content)
-
-## Code Quality Checklist
-
-Before marking work complete:
-- [ ] Code is readable and well-named
-- [ ] Functions are small (<50 lines)
-- [ ] Files are focused (<800 lines)
-- [ ] No deep nesting (>4 levels)
-- [ ] Proper error handling at every level
-- [ ] No hardcoded values (use constants or config)
-- [ ] No mutation (immutable patterns used)
-- [ ] No `console.log` / `System.out.println` in production code
-- [ ] No TODO/FIXME without a linked issue
+- Consistent indentation per language convention (project `.editorconfig` or formatter config)
+- Max line length per formatter config
+- No trailing whitespace
+- Files end with a single newline
+- Organize code by feature/domain, not by type

--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -1,0 +1,51 @@
+---
+applyTo: '**'
+---
+
+# Git Workflow
+
+## Commit Message Format
+```
+<prefix>: <summary>
+
+<optional body>
+
+<optional footer: Also-by: Name <email>>
+```
+
+### Types
+`feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`, `style`
+
+### Rules
+- Use imperative mood: "add feature" not "added feature"
+- Keep subject line under 72 characters
+- One logical change per commit
+- Run `gitlint` locally before pushing
+
+## Branch Naming
+Format: `<type>/<short-description>`
+
+Examples:
+- `feature/add-login`
+- `bugfix/fix-null-pointer`
+- `hotfix/auth-patch`
+
+## Pull Request Workflow
+1. Analyze full commit history: `git diff <base-branch>...HEAD`
+2. Draft comprehensive PR summary covering what changed and why
+3. Include a test plan with verification steps
+4. Push with `-u` flag if new branch
+5. Request review from at least one peer
+
+## Pre-Commit Checklist
+- [ ] All tests pass locally
+- [ ] No lint errors or warnings
+- [ ] No `console.log` / `System.out.println` left in production code
+- [ ] No TODO/FIXME without a linked issue
+- [ ] Commit message follows format above
+- [ ] Branch is rebased on latest base branch
+
+## Merge Strategy
+- Use squash merge when all commits are from the same author and represent one topic
+- Use rebase/merge commit when commits represent distinct topics or multiple authors
+- Preserve clear history and avoid merge commits from `main` into feature branches

--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -2,50 +2,76 @@
 applyTo: '**'
 ---
 
-# Git Workflow
+# Git Workflow — Eclipse S-CORE
 
 ## Commit Message Format
+
 ```
-<prefix>: <summary>
+<prefix>(<scope>): <summary>
 
 <optional body>
 
-<optional footer: Also-by: Name <email>>
+Signed-off-by: Your Name <your.email@example.com>
 ```
 
-### Types
+### Prefixes
+
 `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`, `style`
 
 ### Rules
-- Use imperative mood: "add feature" not "added feature"
-- Keep subject line under 72 characters
+
+- Imperative mood: "add feature" not "added feature"
+- Subject line max 72 characters
 - One logical change per commit
-- Run `gitlint` locally before pushing
+- All commits MUST include `Signed-off-by:` (Eclipse DCO requirement)
+- Run `gitlint` locally before pushing if available
+- Reference related issues: `Fixes #123` or `Refs #456`
+
+### AI Disclosure (when applicable)
+
+Add a trailer when AI tools assisted the commit:
+
+```
+Assisted-by: GitHub Copilot <noreply@github.com>
+Assisted-by: Claude Code <noreply@anthropic.com>
+Assisted-by: Devin <noreply@cognition.ai>
+```
 
 ## Branch Naming
+
 Format: `<type>/<short-description>`
 
 Examples:
-- `feature/add-login`
-- `bugfix/fix-null-pointer`
-- `hotfix/auth-patch`
+- `feat/add-can-transport`
+- `fix/buffer-overflow-handler`
+- `docs/update-architecture`
 
 ## Pull Request Workflow
-1. Analyze full commit history: `git diff <base-branch>...HEAD`
-2. Draft comprehensive PR summary covering what changed and why
+
+1. Create PR using the appropriate template (Bugfix or Improvement)
+2. Mark as draft until ready for review
 3. Include a test plan with verification steps
-4. Push with `-u` flag if new branch
-5. Request review from at least one peer
+4. Ensure all CI checks pass before requesting review
+5. Request review from CODEOWNERS (triggered automatically)
+6. At least one committer must approve before merge
 
 ## Pre-Commit Checklist
-- [ ] All tests pass locally
-- [ ] No lint errors or warnings
-- [ ] No `console.log` / `System.out.println` left in production code
+
+- [ ] All tests pass (`bazel test //...` or equivalent)
+- [ ] No lint errors (`clang-tidy`, `clippy`, `ruff check`)
+- [ ] No debug output left in production code
 - [ ] No TODO/FIXME without a linked issue
 - [ ] Commit message follows format above
-- [ ] Branch is rebased on latest base branch
+- [ ] `Signed-off-by` trailer present (ECA/DCO requirement)
 
 ## Merge Strategy
-- Use squash merge when all commits are from the same author and represent one topic
-- Use rebase/merge commit when commits represent distinct topics or multiple authors
-- Preserve clear history and avoid merge commits from `main` into feature branches
+
+- Squash merge for single-topic PRs from one author
+- Rebase/merge commit for multi-topic PRs or multiple authors
+- Never merge `main` into feature branches — rebase instead
+
+## Eclipse Foundation Requirements
+
+- All contributors must sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/eca/)
+- All commits must include DCO sign-off
+- Commit messages must follow [Eclipse Foundation commit rules](https://www.eclipse.org/projects/handbook/#resources-commit)

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,87 @@
+---
+applyTo: '**/*.py'
+---
+
+# Python Guidelines
+
+## Project Structure
+```
+project-root/
+├── README.md
+├── requirements.txt or pyproject.toml
+├── src/mypackage/
+│   ├── __init__.py
+│   └── module1.py
+├── scripts/
+│   └── run_analysis.py
+└── tests/
+    ├── __init__.py
+    └── test_module1.py
+```
+- Source code in dedicated package directory (`src/mypackage/`)
+- Scripts in `scripts/` with `if __name__ == "__main__":` entry points
+- Tests in parallel `tests/` directory mirroring code structure
+
+## Code Style
+- Follow PEP 8; use auto-formatting (Black) and linting (ruff/flake8)
+- `snake_case` for modules/functions, `CapWords` for classes, `UPPER_SNAKE_CASE` for constants
+- Explicit, descriptive names for all identifiers
+- Imports at top: standard library, third-party, local -- with blank lines between
+- Absolute imports only; no wildcard imports
+- Docstrings for all public modules, classes, functions, methods
+- Minimize comments -- code must be self-explanatory
+
+## Function & Parameter Rules
+- **Never use mutable default arguments** (lists, dicts) -- use `None` and create inside function
+- **No blank strings/lists as defaults**
+- **No `.get()` for required dict keys** -- access directly so missing keys raise errors
+- Check explicitly for `None` or absence for optional values
+
+## Error Handling
+- Catch specific exception types only -- never bare `except:`
+- Use `logging` module, never `print()`
+- Log or re-raise errors appropriately
+
+## Type Hints & Readability
+- Use type hints to clarify input/output types
+- Small, focused functions (Single Responsibility)
+- Prefer comprehensions and built-ins for clarity
+- Avoid deep nesting; break logic into helpers
+
+## Dependencies & Configuration
+- Pin all dependency versions in `requirements.txt` or `pyproject.toml`
+- Always use virtual environments
+- Environment variables or config files for secrets -- never hardcode
+- `.gitignore` excludes venvs, caches, non-source artifacts
+
+## Security
+- **No hardcoded secrets** — use environment variables, `.env` files (in `.gitignore`), or secret managers
+- **Parameterized queries only** — never use f-strings or `%` formatting for SQL
+- **Path traversal prevention** — validate and sanitize all file paths; reject `..` components
+- **Input validation** at API boundaries — use Pydantic models or marshmallow schemas
+- **No `eval()` or `exec()`** on user input — ever
+- **Dependency scanning** — use `pip-audit` or `safety` in CI pipeline
+- **No sensitive data in logs** — mask PII, tokens, passwords
+
+## Data Validation with Pydantic
+- Use Pydantic `BaseModel` for request/response validation at API boundaries
+- Define strict types with `Field()` constraints (`min_length`, `max_length`, `ge`, `le`)
+- Use `@validator` or `@field_validator` for custom validation logic
+- Return Pydantic models from service layer for type safety
+
+## Testing
+- **TDD mandatory**: RED → GREEN → REFACTOR for new features and bug fixes
+- pytest for all testing
+- `test_` prefix for files and functions
+- Use pytest fixtures for shared setup
+- Never mix tests with production code
+- Happy path + edge case tests with clear assertions
+- Use `@pytest.mark.parametrize` for data-driven tests
+- `unittest.mock` for external dependencies
+- Min 80% coverage; 100% for security-critical code
+- Use `pytest-cov` for coverage enforcement in CI
+
+## General
+- Prefer standard library; add third-party only for clear benefit
+- Validate and sanitize all inputs; no silent failures
+- Use context managers (`with`) for resource management

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -2,86 +2,71 @@
 applyTo: '**/*.py'
 ---
 
-# Python Guidelines
+# Python Guidelines — Eclipse S-CORE
+
+## Tooling
+
+- Package manager: `uv` (not pip directly)
+- Formatter: `ruff format`
+- Linter: `ruff check`
+- Type checker: `basedpyright`
+- Test runner: `pytest`
+- Build system: Bazel for integrated builds, `pyproject.toml` for standalone tools
 
 ## Project Structure
+
 ```
 project-root/
-├── README.md
-├── requirements.txt or pyproject.toml
-├── src/mypackage/
+├── pyproject.toml          # Dependencies, metadata, tool config
+├── uv.lock                 # Lockfile (committed)
+├── src/package_name/       # Source code
 │   ├── __init__.py
-│   └── module1.py
-├── scripts/
-│   └── run_analysis.py
+│   └── module.py
 └── tests/
     ├── __init__.py
-    └── test_module1.py
+    └── test_module.py
 ```
-- Source code in dedicated package directory (`src/mypackage/`)
-- Scripts in `scripts/` with `if __name__ == "__main__":` entry points
-- Tests in parallel `tests/` directory mirroring code structure
 
 ## Code Style
-- Follow PEP 8; use auto-formatting (Black) and linting (ruff/flake8)
-- `snake_case` for modules/functions, `CapWords` for classes, `UPPER_SNAKE_CASE` for constants
-- Explicit, descriptive names for all identifiers
-- Imports at top: standard library, third-party, local -- with blank lines between
-- Absolute imports only; no wildcard imports
-- Docstrings for all public modules, classes, functions, methods
-- Minimize comments -- code must be self-explanatory
+
+- `snake_case` for functions/variables, `CapWords` for classes, `UPPER_SNAKE_CASE` for constants
+- Type hints on all public functions and methods
+- Imports at top: standard library, third-party, local — blank lines between groups
+- Absolute imports only; no wildcard imports (`from x import *`)
+- Docstrings on all public modules, classes, and functions
 
 ## Function & Parameter Rules
-- **Never use mutable default arguments** (lists, dicts) -- use `None` and create inside function
-- **No blank strings/lists as defaults**
-- **No `.get()` for required dict keys** -- access directly so missing keys raise errors
-- Check explicitly for `None` or absence for optional values
+
+- Never use mutable default arguments (`list`, `dict`) — use `None` and create inside
+- No `.get()` for required dict keys — access directly so missing keys raise immediately
+- Check explicitly for `None` for optional values
+- Small focused functions — single responsibility
 
 ## Error Handling
-- Catch specific exception types only -- never bare `except:`
-- Use `logging` module, never `print()`
-- Log or re-raise errors appropriately
 
-## Type Hints & Readability
-- Use type hints to clarify input/output types
-- Small, focused functions (Single Responsibility)
-- Prefer comprehensions and built-ins for clarity
-- Avoid deep nesting; break logic into helpers
+- Catch specific exception types — never bare `except:`
+- Use `logging` module, never `print()` in library code
+- Re-raise or log with context — never silently swallow
 
-## Dependencies & Configuration
-- Pin all dependency versions in `requirements.txt` or `pyproject.toml`
-- Always use virtual environments
-- Environment variables or config files for secrets -- never hardcode
-- `.gitignore` excludes venvs, caches, non-source artifacts
+## Dependencies
 
-## Security
-- **No hardcoded secrets** — use environment variables, `.env` files (in `.gitignore`), or secret managers
-- **Parameterized queries only** — never use f-strings or `%` formatting for SQL
-- **Path traversal prevention** — validate and sanitize all file paths; reject `..` components
-- **Input validation** at API boundaries — use Pydantic models or marshmallow schemas
-- **No `eval()` or `exec()`** on user input — ever
-- **Dependency scanning** — use `pip-audit` or `safety` in CI pipeline
-- **No sensitive data in logs** — mask PII, tokens, passwords
-
-## Data Validation with Pydantic
-- Use Pydantic `BaseModel` for request/response validation at API boundaries
-- Define strict types with `Field()` constraints (`min_length`, `max_length`, `ge`, `le`)
-- Use `@validator` or `@field_validator` for custom validation logic
-- Return Pydantic models from service layer for type safety
+- All deps declared in `pyproject.toml`
+- Use `uv sync` to install (creates deterministic lockfile)
+- Virtual environments managed by `uv` automatically
+- Prefer standard library; add third-party only for clear benefit
 
 ## Testing
-- **TDD mandatory**: RED → GREEN → REFACTOR for new features and bug fixes
+
 - pytest for all testing
 - `test_` prefix for files and functions
-- Use pytest fixtures for shared setup
-- Never mix tests with production code
-- Happy path + edge case tests with clear assertions
-- Use `@pytest.mark.parametrize` for data-driven tests
-- `unittest.mock` for external dependencies
-- Min 80% coverage; 100% for security-critical code
-- Use `pytest-cov` for coverage enforcement in CI
+- Use fixtures for shared setup
+- Happy path + edge cases + error cases
+- `pytest-cov` for coverage enforcement
 
-## General
-- Prefer standard library; add third-party only for clear benefit
-- Validate and sanitize all inputs; no silent failures
-- Use context managers (`with`) for resource management
+## Security
+
+- No hardcoded secrets — use environment variables
+- No `eval()` or `exec()` on untrusted input
+- Validate and sanitize file paths — reject `..` components
+- No sensitive data in logs — mask PII, tokens, passwords
+- Use `secrets` module for security-sensitive random values (not `random`)

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -1,0 +1,54 @@
+---
+applyTo: '**'
+---
+
+# Security Guidelines
+
+## Mandatory Checks Before Every Commit
+- [ ] No hardcoded secrets (API keys, passwords, tokens)
+- [ ] All user inputs validated at system boundaries
+- [ ] SQL injection prevention (parameterized queries only)
+- [ ] XSS prevention (sanitized HTML output)
+- [ ] CSRF protection enabled
+- [ ] Authentication and authorization verified
+- [ ] Rate limiting on public endpoints
+- [ ] Error messages do not leak internal details
+
+## Secret Management
+- NEVER hardcode secrets in source code
+- Use environment variables or a secret/config manager
+- Validate required secrets are present at startup
+- Rotate any secrets that may have been exposed
+- Keep files with secrets in `.gitignore`
+
+## Input Validation
+- Validate all user input before processing
+- Use schema-based validation where available (Bean Validation, Zod, Pydantic)
+- Fail fast with clear error messages
+- Never trust external data (API responses, user input, file content)
+
+## Dependency Security
+- Audit transitive dependencies regularly
+- Use OWASP Dependency-Check, Snyk, or Dependabot for CVE scanning
+- Keep dependencies updated with automated tooling
+- Pin versions in production deployments
+
+## Error Responses
+- Never expose stack traces in API responses
+- Map exceptions to safe, generic client messages at handler boundaries
+- Log detailed errors server-side only
+- Maintain an ErrorCode mapping for consistent client-facing messages
+
+## Authentication
+- Never implement custom auth crypto — use established libraries
+- Store passwords with bcrypt or Argon2 (never MD5/SHA1)
+- Enforce authorization checks at service boundaries
+- Never log passwords, tokens, or PII
+
+## Security Response Protocol
+If a security issue is found during development:
+1. STOP current work immediately
+2. Assess severity (Critical / High / Medium / Low)
+3. Fix CRITICAL issues before continuing any other work
+4. Rotate any potentially exposed secrets
+5. Review codebase for similar patterns

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -2,53 +2,75 @@
 applyTo: '**'
 ---
 
-# Security Guidelines
+# Security Guidelines — Eclipse S-CORE
 
 ## Mandatory Checks Before Every Commit
-- [ ] No hardcoded secrets (API keys, passwords, tokens)
-- [ ] All user inputs validated at system boundaries
-- [ ] SQL injection prevention (parameterized queries only)
-- [ ] XSS prevention (sanitized HTML output)
-- [ ] CSRF protection enabled
-- [ ] Authentication and authorization verified
-- [ ] Rate limiting on public endpoints
-- [ ] Error messages do not leak internal details
+
+- [ ] No hardcoded secrets (API keys, passwords, tokens, private keys)
+- [ ] No credentials in comments, log messages, or test fixtures
+- [ ] All external inputs validated at system boundaries
+- [ ] Memory safety verified (no buffer overflows, use-after-free, double-free)
+- [ ] No undefined behavior in C++ code
+- [ ] Error messages do not leak internal details or memory addresses
 
 ## Secret Management
-- NEVER hardcode secrets in source code
-- Use environment variables or a secret/config manager
-- Validate required secrets are present at startup
+
+- NEVER hardcode secrets in source code — use environment variables or secret managers
+- NEVER commit `.env`, `credentials.json`, or key files
+- Keep secret-containing files in `.gitignore`
 - Rotate any secrets that may have been exposed
-- Keep files with secrets in `.gitignore`
+
+## Memory Safety (C++)
+
+- Use RAII for all resource management
+- Prefer smart pointers (`std::unique_ptr`, `std::shared_ptr`) over raw pointers
+- Use `std::span` and `std::string_view` for bounds-safe access
+- Run sanitizers in CI: ASan, UBSan, LSan, TSan (see `score_cpp_policies`)
+- No `reinterpret_cast` without explicit justification
+- No manual `new`/`delete` — use container types or smart pointers
+- Validate array indices and buffer sizes at boundaries
+
+## Memory Safety (Rust)
+
+- No `unsafe` blocks without explicit justification and safety comments
+- Minimize `unsafe` scope — wrap in safe abstractions
+- All `unsafe` blocks must document why safety invariants are upheld
+- Prefer `checked_add`, `checked_mul` over wrapping arithmetic for sizes/offsets
+
+## Cryptography
+
+- NEVER implement custom cryptographic algorithms
+- Use established libraries (OpenSSL, BoringSSL, ring, RustCrypto)
+- Use `std::random_device` or `getrandom` for security-sensitive randomness — not `rand()`
+- TLS 1.2+ for all network communication
+
+## Supply Chain Security
+
+- Audit transitive dependencies regularly
+- Use Dependabot / OWASP Dependency-Check for CVE scanning
+- Pin dependency versions in `MODULE.bazel`
+- Verify integrity of downloaded artifacts (checksums, signatures)
 
 ## Input Validation
-- Validate all user input before processing
-- Use schema-based validation where available (Bean Validation, Zod, Pydantic)
-- Fail fast with clear error messages
-- Never trust external data (API responses, user input, file content)
 
-## Dependency Security
-- Audit transitive dependencies regularly
-- Use OWASP Dependency-Check, Snyk, or Dependabot for CVE scanning
-- Keep dependencies updated with automated tooling
-- Pin versions in production deployments
+- Validate all data from external sources (network, files, IPC)
+- Check buffer sizes before copy operations
+- Reject malformed input early — fail fast
+- Never trust data from untrusted processes or external ECUs without validation
 
-## Error Responses
-- Never expose stack traces in API responses
-- Map exceptions to safe, generic client messages at handler boundaries
-- Log detailed errors server-side only
-- Maintain an ErrorCode mapping for consistent client-facing messages
+## Embedded / Automotive Specific
 
-## Authentication
-- Never implement custom auth crypto — use established libraries
-- Store passwords with bcrypt or Argon2 (never MD5/SHA1)
-- Enforce authorization checks at service boundaries
-- Never log passwords, tokens, or PII
+- No dynamic memory allocation in safety-critical paths after initialization
+- Privilege isolation: separate safety-critical from non-critical components
+- Communication channel authentication between ECUs
+- Log security-relevant events for post-incident analysis
+- Follow ISO 21434 (cybersecurity engineering) requirements where applicable
 
 ## Security Response Protocol
+
 If a security issue is found during development:
 1. STOP current work immediately
 2. Assess severity (Critical / High / Medium / Low)
 3. Fix CRITICAL issues before continuing any other work
 4. Rotate any potentially exposed secrets
-5. Review codebase for similar patterns
+5. Report via SECURITY.md disclosure process

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,53 @@
+---
+applyTo: '**'
+---
+
+# Testing Requirements
+
+## Minimum Coverage: 80%
+
+100% required for:
+- Financial calculations
+- Authentication logic
+- Security-critical code
+- Core business logic
+
+## Test Types (ALL required for production features)
+1. **Unit Tests** — Individual functions, utilities, components
+2. **Integration Tests** — API endpoints, database operations, service interactions
+3. **System/Scenario Tests** — Critical cross-component flows where applicable
+
+## Test-Driven Development (TDD)
+
+Mandatory workflow for new features and bug fixes:
+1. **RED** — Write a failing test first
+2. **GREEN** — Write minimal implementation to pass
+3. **REFACTOR** — Improve code while keeping tests green
+4. Repeat for each scenario
+
+### Rules
+- Never write implementation before the test
+- Run tests after every change
+- Write minimal code to make tests pass
+- Refactor only when tests are green
+
+## Test Structure
+- Arrange-Act-Assert (AAA) pattern
+- One logical assertion per test (max 3 related assertions)
+- Descriptive test names: `methodName_scenario_expectedBehavior`
+- Use `@DisplayName` or equivalent for human-readable descriptions
+
+## Test Quality
+- Tests must be independent and isolated
+- No shared mutable state between tests
+- Fast execution (unit tests < 100ms each)
+- Deterministic — no flaky tests
+- Fix implementation, not tests (unless tests are wrong)
+
+## Language-Specific Frameworks
+| Language | Unit | Mocking | Integration | Coverage |
+|----------|------|---------|-------------|----------|
+| C++ | GoogleTest | GoogleMock | Bazel test targets | lcov/gcov |
+| Python | pytest | unittest.mock | pytest + service/integration fixtures | pytest-cov |
+| Rust | cargo test | mockall (or equivalent) | integration tests in `tests/` | llvm-cov/grcov |
+| Go | go test | gomock/testify | package/integration tests | go test -cover |

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -2,52 +2,87 @@
 applyTo: '**'
 ---
 
-# Testing Requirements
+# Testing Requirements — Eclipse S-CORE
 
-## Minimum Coverage: 80%
+## Build & Test System
 
-100% required for:
-- Financial calculations
-- Authentication logic
-- Security-critical code
-- Core business logic
+All S-CORE modules use Bazel as the primary build and test system:
 
-## Test Types (ALL required for production features)
+```bash
+# Build all targets
+bazel build //...
+
+# Run all tests
+bazel test //...
+
+# Run tests with sanitizers (from score_cpp_policies)
+bazel test --config=asan_ubsan_lsan //...   # Memory errors + UB + leaks
+bazel test --config=tsan //...               # Thread safety (separate run)
+
+# Run clang-tidy
+bazel build --config=clang-tidy //...
+
+# Run Clippy (Rust)
+bazel build --config=clippy-strict //...     # Safety-critical code
+bazel build --config=clippy-relaxed //...    # Tooling and tests
+```
+
+## Coverage
+
+- Minimum 80% for general code
+- 100% required for:
+  - Safety-critical code paths
+  - Platform abstraction layers
+  - Security-sensitive logic
+  - Communication protocol handlers
+
+## Test Types
+
 1. **Unit Tests** — Individual functions, utilities, components
-2. **Integration Tests** — API endpoints, database operations, service interactions
-3. **System/Scenario Tests** — Critical cross-component flows where applicable
+2. **Integration Tests** — Cross-component interactions, IPC, service communication
+3. **System Tests** — End-to-end flows in `reference_integration` where applicable
 
 ## Test-Driven Development (TDD)
 
-Mandatory workflow for new features and bug fixes:
+For new features and bug fixes:
 1. **RED** — Write a failing test first
-2. **GREEN** — Write minimal implementation to pass
-3. **REFACTOR** — Improve code while keeping tests green
-4. Repeat for each scenario
-
-### Rules
-- Never write implementation before the test
-- Run tests after every change
-- Write minimal code to make tests pass
-- Refactor only when tests are green
+2. **GREEN** — Minimal implementation to pass
+3. **REFACTOR** — Improve while keeping tests green
 
 ## Test Structure
+
 - Arrange-Act-Assert (AAA) pattern
 - One logical assertion per test (max 3 related assertions)
-- Descriptive test names: `methodName_scenario_expectedBehavior`
-- Use `@DisplayName` or equivalent for human-readable descriptions
-
-## Test Quality
-- Tests must be independent and isolated
+- Descriptive test names: `test_<unit>_<scenario>_<expected>`
+- Tests must be independent, isolated, deterministic (no flakiness)
 - No shared mutable state between tests
-- Fast execution (unit tests < 100ms each)
-- Deterministic — no flaky tests
-- Fix implementation, not tests (unless tests are wrong)
 
 ## Language-Specific Frameworks
-| Language | Unit | Mocking | Integration | Coverage |
-|----------|------|---------|-------------|----------|
-| C++ | GoogleTest | GoogleMock | Bazel test targets | lcov/gcov |
-| Python | pytest | unittest.mock | pytest + service/integration fixtures | pytest-cov |
-| Rust | cargo test | mockall (or equivalent) | integration tests in `tests/` | llvm-cov/grcov |
-| Go | go test | gomock/testify | package/integration tests | go test -cover |
+
+| Language | Unit | Mocking | Sanitizers | Coverage |
+|----------|------|---------|------------|----------|
+| C++ | GoogleTest | GoogleMock | ASan, UBSan, LSan, TSan | lcov/gcov |
+| Rust | `#[test]` / cargo test | mockall | Clippy strict/relaxed | llvm-cov/grcov |
+| Python | pytest | unittest.mock | N/A | pytest-cov |
+| Starlark | Bazel test rules | N/A | N/A | N/A |
+
+## Sanitizer Tags
+
+Use tags to skip tests incompatible with specific sanitizers:
+
+```python
+cc_test(
+    name = "my_test",
+    srcs = ["my_test.cpp"],
+    tags = ["no-tsan"],  # Skip under ThreadSanitizer
+)
+```
+
+Available tags: `no-tsan`, `no-asan`, `no-lsan`, `no-ubsan`
+
+## Test Quality
+
+- Fast execution (unit tests < 100ms each)
+- Fix implementation, not tests (unless tests are wrong)
+- Never commit tests that are expected to fail without a linked issue
+- Tag long-running integration tests appropriately


### PR DESCRIPTION
## Scope

This PR adds the shared SCORE instruction pack under `.github/instructions/`.

## Why

Extracted from oversized PR #51 to keep review focused and faster.

## Out of scope

- governance schemas and manifest
- copier template distribution
- docs and hygiene automation

## Validation

- one focused branch/commit slice for shared instructions

## Merge Order

1. #54 (core contracts)
2. #55 (instruction pack)
3. #56 (copier template)
4. #57 (docs and hygiene)

## Relationship to original PR

This PR is part of the split of oversized PR #51.