### PR TITLE
feat: add copier template for governance distribution

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -1,0 +1,64 @@
+# SCORE governance overlay — Copier template configuration
+# Adopter repos run:
+#   copier copy gh:eclipse-score/.github path/to/repo
+#   copier update   (from inside the adopter repo to pull latest SCORE changes)
+
+_subdirectory: template
+_answers_file: .github/score/.copier-answers.yml
+
+_message_after_copy: |
+  SCORE governance overlay applied.
+
+  Next steps:
+    1. Review AGENTS.md as the canonical cross-assistant policy.
+    2. If needed, add assistant-specific notes in CLAUDE.md or .github/<instructions-file>.
+    3. Review .github/score/repo-manifest.json — update build/test/lint commands.
+    4. Commit the generated files.
+    5. Run: python3 scripts/check_markdown_hygiene.py --root . --include .github
+    6. To update SCORE governance in future: copier update
+
+# ── Questions ────────────────────────────────────────────────────────────────
+
+repo_name:
+  type: str
+  help: Repository name (used in repo-manifest.json, e.g. score-baselibc)
+
+repo_language:
+  type: str
+  help: Primary language
+  choices:
+    - C++
+    - Rust
+    - Python
+    - Go
+    - Other
+
+repo_visibility:
+  type: str
+  help: Repository visibility
+  default: public
+  choices:
+    - public
+    - private
+
+build_command:
+  type: str
+  help: Build command (e.g. "bazel build //...")
+  default: "bazel build //..."
+
+test_command:
+  type: str
+  help: Test command (e.g. "bazel test //...")
+  default: "bazel test //..."
+
+lint_command:
+  type: str
+  help: Lint command (e.g. "bazel run //:lint")
+  default: "bazel run //:lint"
+
+assistant_instructions_file:
+  type: str
+  help: >
+    Filename your AI assistant loads as instructions
+    (Copilot commonly uses copilot-instructions.md; other runtimes may use a different name)
+  default: copilot-instructions.md

--- a/template/.claude/settings.json
+++ b/template/.claude/settings.json
@@ -1,13 +1,1 @@
-{
-  "extraKnownMarketplaces": {
-    "score-agent-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "eclipse-score/agent-plugins"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "score-governance@score-agent-plugins": true
-  }
-}
+{}

--- a/template/.claude/settings.json
+++ b/template/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "score-agent-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "eclipse-score/agent-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "score-governance@score-agent-plugins": true
+  }
+}

--- a/template/.github/copilot/settings.json
+++ b/template/.github/copilot/settings.json
@@ -1,13 +1,1 @@
-{
-  "extraKnownMarketplaces": {
-    "score-agent-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "eclipse-score/agent-plugins"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "score-governance@score-agent-plugins": true
-  }
-}
+{}

--- a/template/.github/copilot/settings.json
+++ b/template/.github/copilot/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "score-agent-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "eclipse-score/agent-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "score-governance@score-agent-plugins": true
+  }
+}

--- a/template/.github/instructions/clean-code.instructions.md
+++ b/template/.github/instructions/clean-code.instructions.md
@@ -1,0 +1,93 @@
+---
+applyTo: '**'
+---
+
+# Clean Code Guidelines (All Languages)
+
+## Goal
+Code is *extremely readable*, composed of *very small and focused* methods/functions, and avoids all code smells.
+
+## General Principles
+- Code is for **humans first**, computers second
+- Express intent clearly -- self-explanatory names for variables, methods, classes
+- Prefer self-documenting code; comments as last resort
+- **Small is beautiful** -- small, focused methods and classes
+- Duplication is a bad sign -- extract and reuse
+- KISS -- reduce complexity as much as possible
+- YAGNI -- avoid over-engineering
+- Boy Scout Rule -- leave the codebase cleaner than you found it
+- Tell, Don't Ask -- promote loose coupling
+- Be Consistent -- follow existing conventions
+- Encapsulate boundary conditions in one place
+- Avoid negative conditionals
+- Use dependency injection
+
+## SOLID Principles
+- **SRP**: Each method/class does one thing only
+- **OCP**: Open for extension, closed for modification
+- **LSP**: Subtypes substitutable for base types
+- **ISP**: Small, focused interfaces
+- **DIP**: Depend on abstractions, not concretions
+
+## Code Smells to Remove
+Long Method, Large Class, Primitive Obsession, Long Parameter List (max 3), Data Clumps, Switch Statements, Temporary Field, Divergent Change, Shotgun Surgery, Duplicated Code, Dead Code, Feature Envy, Middle Man, Magic Numbers (replace with named constants).
+
+## Class Design
+- Small: max ~7 fields, ~3-5 public methods
+- Single clear purpose aligned with domain
+- Domain-focused naming (e.g. `PolicyRenewalService`, not `HelperUtil`)
+- Encapsulation -- hide internal structure
+- Prefer immutability, composition over inheritance
+- Follow Law of Demeter
+- Prefer value objects over primitives
+- Avoid God objects and util classes
+
+## Method Design
+- Ideal length: ~3 lines, rarely more than 5
+- Single atomic step of logic
+- Names describe *what* not *how*
+- No side effects
+- Use guard clauses / early returns
+- Avoid nested ifs/loops
+- No flag arguments -- split into separate methods
+- Extract complex predicates into named boolean methods
+
+## Test Design
+- Small, specific, isolated, fast, independent, repeatable
+- Arrange-Act-Assert format
+- Max 3 assertions per test
+- Always test new public behavior
+- At least one negative test per API
+- Avoid duplicated test data -- extract to class level
+
+## Naming
+- Descriptive and unambiguous
+- Methods: verbs. Classes: nouns. Variables: clear names
+- Pronounceable, searchable, no encodings
+
+## Comments
+- Explain *why*, not *what*
+- Document assumptions, invariants, edge cases
+- Never comment out code -- just remove it
+
+## Error Handling
+- Use domain-specific custom exceptions
+- Handle exceptions gracefully; never swallow them
+- Externalize user-facing messages
+- Maintain ErrorCode mapping
+
+## Security
+- No hardcoded secrets, URLs, or sensitive info
+- All sensitive config resolved via environment or config server
+- PII protection: data masking, tokenization
+
+## Performance
+- Avoid premature micro-optimizations unless profiled
+- Batch operations in single transactions
+- Refactor nested loops into indexed maps (O(n+m))
+
+## API Design
+- RESTful conventions with domain-driven design
+- Plural noun resources: `/v1/templates`
+- Accept filtering & expansion parameters
+- Consistent resource naming

--- a/template/.github/instructions/coding-style.instructions.md
+++ b/template/.github/instructions/coding-style.instructions.md
@@ -1,0 +1,65 @@
+---
+applyTo: '**'
+---
+
+# Coding Style
+
+## Immutability (CRITICAL)
+
+ALWAYS create new objects, NEVER mutate existing ones:
+- Return new instances rather than modifying in place
+- Use spread operators, `List.copyOf()`, `Map.copyOf()`, or equivalent
+- Mark fields `final` / `readonly` / `const` by default
+
+Rationale: Immutable data prevents hidden side effects, makes debugging easier, and enables safe concurrency.
+
+## File Organization
+
+MANY SMALL FILES > FEW LARGE FILES:
+- High cohesion, low coupling
+- 200-400 lines typical, 800 max
+- Extract utilities from large modules
+- Organize by feature/domain, not by type
+
+## Function Size
+
+- Ideal: 3-10 lines, rarely more than 20
+- Max: 50 lines — split if exceeded
+- Single atomic step of logic per function
+- No flag arguments — split into separate functions
+
+## Nesting
+
+- Max 4 levels of nesting
+- Use guard clauses and early returns to flatten
+- Extract complex predicates into named boolean methods
+- Extract inner loops into helper functions
+
+## Error Handling
+
+ALWAYS handle errors comprehensively:
+- Handle errors explicitly at every level
+- Provide user-friendly error messages in UI-facing code
+- Log detailed error context on the server side
+- Never silently swallow errors
+
+## Input Validation
+
+ALWAYS validate at system boundaries:
+- Validate all user input before processing
+- Use schema-based validation where available
+- Fail fast with clear error messages
+- Never trust external data (API responses, user input, file content)
+
+## Code Quality Checklist
+
+Before marking work complete:
+- [ ] Code is readable and well-named
+- [ ] Functions are small (<50 lines)
+- [ ] Files are focused (<800 lines)
+- [ ] No deep nesting (>4 levels)
+- [ ] Proper error handling at every level
+- [ ] No hardcoded values (use constants or config)
+- [ ] No mutation (immutable patterns used)
+- [ ] No `console.log` / `System.out.println` in production code
+- [ ] No TODO/FIXME without a linked issue

--- a/template/.github/instructions/git-workflow.instructions.md
+++ b/template/.github/instructions/git-workflow.instructions.md
@@ -1,0 +1,51 @@
+---
+applyTo: '**'
+---
+
+# Git Workflow
+
+## Commit Message Format
+```
+<prefix>: <summary>
+
+<optional body>
+
+<optional footer: Also-by: Name <email>>
+```
+
+### Types
+`feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`, `style`
+
+### Rules
+- Use imperative mood: "add feature" not "added feature"
+- Keep subject line under 72 characters
+- One logical change per commit
+- Run `gitlint` locally before pushing
+
+## Branch Naming
+Format: `<type>/<short-description>`
+
+Examples:
+- `feature/add-login`
+- `bugfix/fix-null-pointer`
+- `hotfix/auth-patch`
+
+## Pull Request Workflow
+1. Analyze full commit history: `git diff <base-branch>...HEAD`
+2. Draft comprehensive PR summary covering what changed and why
+3. Include a test plan with verification steps
+4. Push with `-u` flag if new branch
+5. Request review from at least one peer
+
+## Pre-Commit Checklist
+- [ ] All tests pass locally
+- [ ] No lint errors or warnings
+- [ ] No `console.log` / `System.out.println` left in production code
+- [ ] No TODO/FIXME without a linked issue
+- [ ] Commit message follows format above
+- [ ] Branch is rebased on latest base branch
+
+## Merge Strategy
+- Use squash merge when all commits are from the same author and represent one topic
+- Use rebase/merge commit when commits represent distinct topics or multiple authors
+- Preserve clear history and avoid merge commits from `main` into feature branches

--- a/template/.github/instructions/python.instructions.md
+++ b/template/.github/instructions/python.instructions.md
@@ -1,0 +1,87 @@
+---
+applyTo: '**/*.py'
+---
+
+# Python Guidelines
+
+## Project Structure
+```
+project-root/
+├── README.md
+├── requirements.txt or pyproject.toml
+├── src/mypackage/
+│   ├── __init__.py
+│   └── module1.py
+├── scripts/
+│   └── run_analysis.py
+└── tests/
+    ├── __init__.py
+    └── test_module1.py
+```
+- Source code in dedicated package directory (`src/mypackage/`)
+- Scripts in `scripts/` with `if __name__ == "__main__":` entry points
+- Tests in parallel `tests/` directory mirroring code structure
+
+## Code Style
+- Follow PEP 8; use auto-formatting (Black) and linting (ruff/flake8)
+- `snake_case` for modules/functions, `CapWords` for classes, `UPPER_SNAKE_CASE` for constants
+- Explicit, descriptive names for all identifiers
+- Imports at top: standard library, third-party, local -- with blank lines between
+- Absolute imports only; no wildcard imports
+- Docstrings for all public modules, classes, functions, methods
+- Minimize comments -- code must be self-explanatory
+
+## Function & Parameter Rules
+- **Never use mutable default arguments** (lists, dicts) -- use `None` and create inside function
+- **No blank strings/lists as defaults**
+- **No `.get()` for required dict keys** -- access directly so missing keys raise errors
+- Check explicitly for `None` or absence for optional values
+
+## Error Handling
+- Catch specific exception types only -- never bare `except:`
+- Use `logging` module, never `print()`
+- Log or re-raise errors appropriately
+
+## Type Hints & Readability
+- Use type hints to clarify input/output types
+- Small, focused functions (Single Responsibility)
+- Prefer comprehensions and built-ins for clarity
+- Avoid deep nesting; break logic into helpers
+
+## Dependencies & Configuration
+- Pin all dependency versions in `requirements.txt` or `pyproject.toml`
+- Always use virtual environments
+- Environment variables or config files for secrets -- never hardcode
+- `.gitignore` excludes venvs, caches, non-source artifacts
+
+## Security
+- **No hardcoded secrets** — use environment variables, `.env` files (in `.gitignore`), or secret managers
+- **Parameterized queries only** — never use f-strings or `%` formatting for SQL
+- **Path traversal prevention** — validate and sanitize all file paths; reject `..` components
+- **Input validation** at API boundaries — use Pydantic models or marshmallow schemas
+- **No `eval()` or `exec()`** on user input — ever
+- **Dependency scanning** — use `pip-audit` or `safety` in CI pipeline
+- **No sensitive data in logs** — mask PII, tokens, passwords
+
+## Data Validation with Pydantic
+- Use Pydantic `BaseModel` for request/response validation at API boundaries
+- Define strict types with `Field()` constraints (`min_length`, `max_length`, `ge`, `le`)
+- Use `@validator` or `@field_validator` for custom validation logic
+- Return Pydantic models from service layer for type safety
+
+## Testing
+- **TDD mandatory**: RED → GREEN → REFACTOR for new features and bug fixes
+- pytest for all testing
+- `test_` prefix for files and functions
+- Use pytest fixtures for shared setup
+- Never mix tests with production code
+- Happy path + edge case tests with clear assertions
+- Use `@pytest.mark.parametrize` for data-driven tests
+- `unittest.mock` for external dependencies
+- Min 80% coverage; 100% for security-critical code
+- Use `pytest-cov` for coverage enforcement in CI
+
+## General
+- Prefer standard library; add third-party only for clear benefit
+- Validate and sanitize all inputs; no silent failures
+- Use context managers (`with`) for resource management

--- a/template/.github/instructions/security.instructions.md
+++ b/template/.github/instructions/security.instructions.md
@@ -1,0 +1,54 @@
+---
+applyTo: '**'
+---
+
+# Security Guidelines
+
+## Mandatory Checks Before Every Commit
+- [ ] No hardcoded secrets (API keys, passwords, tokens)
+- [ ] All user inputs validated at system boundaries
+- [ ] SQL injection prevention (parameterized queries only)
+- [ ] XSS prevention (sanitized HTML output)
+- [ ] CSRF protection enabled
+- [ ] Authentication and authorization verified
+- [ ] Rate limiting on public endpoints
+- [ ] Error messages do not leak internal details
+
+## Secret Management
+- NEVER hardcode secrets in source code
+- Use environment variables or a secret/config manager
+- Validate required secrets are present at startup
+- Rotate any secrets that may have been exposed
+- Keep files with secrets in `.gitignore`
+
+## Input Validation
+- Validate all user input before processing
+- Use schema-based validation where available (Bean Validation, Zod, Pydantic)
+- Fail fast with clear error messages
+- Never trust external data (API responses, user input, file content)
+
+## Dependency Security
+- Audit transitive dependencies regularly
+- Use OWASP Dependency-Check, Snyk, or Dependabot for CVE scanning
+- Keep dependencies updated with automated tooling
+- Pin versions in production deployments
+
+## Error Responses
+- Never expose stack traces in API responses
+- Map exceptions to safe, generic client messages at handler boundaries
+- Log detailed errors server-side only
+- Maintain an ErrorCode mapping for consistent client-facing messages
+
+## Authentication
+- Never implement custom auth crypto — use established libraries
+- Store passwords with bcrypt or Argon2 (never MD5/SHA1)
+- Enforce authorization checks at service boundaries
+- Never log passwords, tokens, or PII
+
+## Security Response Protocol
+If a security issue is found during development:
+1. STOP current work immediately
+2. Assess severity (Critical / High / Medium / Low)
+3. Fix CRITICAL issues before continuing any other work
+4. Rotate any potentially exposed secrets
+5. Review codebase for similar patterns

--- a/template/.github/instructions/testing.instructions.md
+++ b/template/.github/instructions/testing.instructions.md
@@ -1,0 +1,53 @@
+---
+applyTo: '**'
+---
+
+# Testing Requirements
+
+## Minimum Coverage: 80%
+
+100% required for:
+- Financial calculations
+- Authentication logic
+- Security-critical code
+- Core business logic
+
+## Test Types (ALL required for production features)
+1. **Unit Tests** — Individual functions, utilities, components
+2. **Integration Tests** — API endpoints, database operations, service interactions
+3. **System/Scenario Tests** — Critical cross-component flows where applicable
+
+## Test-Driven Development (TDD)
+
+Mandatory workflow for new features and bug fixes:
+1. **RED** — Write a failing test first
+2. **GREEN** — Write minimal implementation to pass
+3. **REFACTOR** — Improve code while keeping tests green
+4. Repeat for each scenario
+
+### Rules
+- Never write implementation before the test
+- Run tests after every change
+- Write minimal code to make tests pass
+- Refactor only when tests are green
+
+## Test Structure
+- Arrange-Act-Assert (AAA) pattern
+- One logical assertion per test (max 3 related assertions)
+- Descriptive test names: `methodName_scenario_expectedBehavior`
+- Use `@DisplayName` or equivalent for human-readable descriptions
+
+## Test Quality
+- Tests must be independent and isolated
+- No shared mutable state between tests
+- Fast execution (unit tests < 100ms each)
+- Deterministic — no flaky tests
+- Fix implementation, not tests (unless tests are wrong)
+
+## Language-Specific Frameworks
+| Language | Unit | Mocking | Integration | Coverage |
+|----------|------|---------|-------------|----------|
+| C++ | GoogleTest | GoogleMock | Bazel test targets | lcov/gcov |
+| Python | pytest | unittest.mock | pytest + service/integration fixtures | pytest-cov |
+| Rust | cargo test | mockall (or equivalent) | integration tests in `tests/` | llvm-cov/grcov |
+| Go | go test | gomock/testify | package/integration tests | go test -cover |

--- a/template/.github/references/agent-card.schema.json
+++ b/template/.github/references/agent-card.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://score.dev/schemas/agent-card.schema.json",
+  "title": "SCORE Agent Card",
+  "description": "Structured handoff artifact exchanged between agents and tools for one issue-scoped work item.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "issue_id",
+    "repository",
+    "goal",
+    "status",
+    "summary",
+    "validation",
+    "next_action"
+  ],
+  "properties": {
+    "version": {
+      "const": 1
+    },
+    "issue_id": {
+      "type": "string",
+      "pattern": "^(ISSUE-[0-9]+|POC-[0-9]{8}-[0-9]{4})$"
+    },
+    "repository": {
+      "type": "string",
+      "minLength": 1
+    },
+    "branch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "goal": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "in_progress",
+        "blocked",
+        "ready_for_handoff",
+        "completed"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/note"
+      },
+      "default": []
+    },
+    "open_questions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "touched_files": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true,
+      "default": []
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "not_run",
+            "passed",
+            "failed"
+          ]
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/commandResult"
+          },
+          "default": []
+        }
+      }
+    },
+    "trajectory": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/note"
+      },
+      "default": []
+    },
+    "next_action": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "$defs": {
+    "note": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "detail"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "commandResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "status"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "passed",
+            "failed"
+          ]
+        },
+        "detail": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/template/.github/references/agent-card.schema.json
+++ b/template/.github/references/agent-card.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://score.dev/schemas/agent-card.schema.json",
-  "title": "SCORE Agent Card",
-  "description": "Structured handoff artifact exchanged between agents and tools for one issue-scoped work item.",
+  "title": "SCORE Work Card (Agent Handoff)",
+  "description": "Structured handoff artifact exchanged between agents and tools for one issue-scoped work item. This schema is a work/handoff artifact and is not the A2A service-discovery AgentCard.",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/template/.github/references/assistant-runtime-alignment.md
+++ b/template/.github/references/assistant-runtime-alignment.md
@@ -1,0 +1,32 @@
+# Assistant Runtime Alignment
+
+This repository distributes one shared policy across multiple assistant runtimes.
+
+## Canonical instruction source
+
+- AGENTS.md is the canonical, runtime-neutral project policy.
+- CLAUDE.md imports AGENTS.md for Claude Code compatibility.
+- .github/<instructions-file> is runtime-specific glue (for example copilot-instructions.md).
+
+## Why this layout
+
+- Codex reads AGENTS.md directly and supports layered AGENTS files.
+- Claude Code reads CLAUDE.md and recommends importing AGENTS.md when both are used.
+- VS Code agent plugins and Codex plugins share compatible plugin concepts (skills, agents, hooks, MCP), so marketplace settings can be aligned.
+
+## Plugin marketplace alignment
+
+The template includes marketplace recommendation stubs in:
+
+- .claude/settings.json
+- .github/copilot/settings.json
+
+Both point to the same marketplace and default plugin identifier so teams can keep tool capabilities aligned.
+
+## Adoption checklist
+
+1. Keep AGENTS.md as the source of truth for shared behavioral policy.
+2. Keep CLAUDE.md minimal and import-first.
+3. Keep .github/<instructions-file> minimal and runtime-specific.
+4. Configure one approved plugin marketplace for all assistant runtimes.
+5. Use copier update to roll out governance and alignment updates.

--- a/template/.github/references/assistant-runtime-alignment.md
+++ b/template/.github/references/assistant-runtime-alignment.md
@@ -12,21 +12,21 @@ This repository distributes one shared policy across multiple assistant runtimes
 
 - Codex reads AGENTS.md directly and supports layered AGENTS files.
 - Claude Code reads CLAUDE.md and recommends importing AGENTS.md when both are used.
-- VS Code agent plugins and Codex plugins share compatible plugin concepts (skills, agents, hooks, MCP), so marketplace settings can be aligned.
+- MCP is the primary runtime integration path across assistants, so governance should align around MCP-first behavior.
 
-## Plugin marketplace alignment
+## Runtime settings alignment
 
-The template includes marketplace recommendation stubs in:
+The template includes runtime settings stubs in:
 
 - .claude/settings.json
 - .github/copilot/settings.json
 
-Both point to the same marketplace and default plugin identifier so teams can keep tool capabilities aligned.
+Use these stubs for runtime-local preferences and MCP-related defaults. Avoid hardcoding plugin marketplace repositories.
 
 ## Adoption checklist
 
 1. Keep AGENTS.md as the source of truth for shared behavioral policy.
 2. Keep CLAUDE.md minimal and import-first.
 3. Keep .github/<instructions-file> minimal and runtime-specific.
-4. Configure one approved plugin marketplace for all assistant runtimes.
+4. Prefer MCP-native integrations over plugin marketplace dependencies.
 5. Use copier update to roll out governance and alignment updates.

--- a/template/.github/references/repo-manifest.schema.json
+++ b/template/.github/references/repo-manifest.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://score.dev/schemas/repo-manifest.schema.json",
+  "title": "SCORE Repo Manifest",
+  "description": "Minimal federated harness contract for a SCORE repository.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "repository",
+    "bootstrap",
+    "execution",
+    "mcp"
+  ],
+  "properties": {
+    "version": {
+      "const": 1
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "language",
+        "visibility"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "language": {
+          "type": "string",
+          "enum": [
+            "python",
+            "go",
+            "rust",
+            "cpp",
+            "typescript",
+            "mixed",
+            "other"
+          ]
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "public",
+            "internal",
+            "private"
+          ]
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true,
+          "default": []
+        }
+      }
+    },
+    "bootstrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_version"
+      ],
+      "properties": {
+        "contract_version": {
+          "type": "string",
+          "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "template_version": {
+          "type": "string",
+          "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+        }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "build",
+        "test",
+        "lint"
+      ],
+      "properties": {
+        "build": {
+          "$ref": "#/$defs/commandSpec"
+        },
+        "test": {
+          "$ref": "#/$defs/commandSpec"
+        },
+        "lint": {
+          "$ref": "#/$defs/commandSpec"
+        },
+        "typecheck": {
+          "$ref": "#/$defs/commandSpec"
+        }
+      }
+    },
+    "mcp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "server_name",
+        "tools"
+      ],
+      "properties": {
+        "server_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "build",
+              "test",
+              "lint",
+              "typecheck",
+              "search"
+            ]
+          },
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      }
+    }
+  },
+  "$defs": {
+    "commandSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "working_directory": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/template/.github/score/repo-manifest.json.jinja
+++ b/template/.github/score/repo-manifest.json.jinja
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "repository": {
+    "name": "{{ repo_name }}",
+    "language": "{{ repo_language }}",
+    "visibility": "{{ repo_visibility }}"
+  },
+  "bootstrap": {
+    "contract_version": "v0.1.0",
+    "template_source": "https://github.com/eclipse-score/.github"
+  },
+  "execution": {
+    "build": {
+      "command": "{{ build_command }}"
+    },
+    "test": {
+      "command": "{{ test_command }}"
+    },
+    "lint": {
+      "command": "{{ lint_command }}"
+    }
+  }
+}

--- a/template/.github/workflows/docs-hygiene.yml
+++ b/template/.github/workflows/docs-hygiene.yml
@@ -1,0 +1,29 @@
+name: Markdown Hygiene
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - 'scripts/check_markdown_hygiene.py'
+      - '.github/workflows/docs-hygiene.yml'
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run markdown hygiene checks
+        run: python scripts/check_markdown_hygiene.py --root . --include .github --include README.md --include profile

--- a/template/.github/{{ assistant_instructions_file }}.jinja
+++ b/template/.github/{{ assistant_instructions_file }}.jinja
@@ -15,6 +15,8 @@ Update distributed policy files by running `copier update` from the repository r
    - `.github/score/repo-manifest.json`
 3. Apply coding standards from `.github/instructions/`.
 
+Terminology note: `.github/references/agent-card.schema.json` defines a SCORE work/handoff artifact, not an A2A service-discovery AgentCard.
+
 ## Artifact Naming
 
 Use issue-scoped stage folders for all work artifacts:
@@ -22,7 +24,7 @@ Use issue-scoped stage folders for all work artifacts:
 ```
 .stage/ISSUE-<number>/
   plan.md
-  agent-card.json
+  work-card.json
 ```
 
 ## SDLC Progress Block

--- a/template/.github/{{ assistant_instructions_file }}.jinja
+++ b/template/.github/{{ assistant_instructions_file }}.jinja
@@ -1,0 +1,44 @@
+You are operating inside the SCORE governance overlay.
+
+This file is runtime-specific glue.
+The canonical, runtime-neutral policy lives in AGENTS.md at repository root.
+
+Keep this file aligned with AGENTS.md and use it only for assistant-runtime specifics.
+Update distributed policy files by running `copier update` from the repository root.
+
+## Responsibilities
+
+1. Preserve issue-first traceability — all work artifacts reference a GitHub issue number.
+2. Honour SCORE contracts:
+   - `.github/references/repo-manifest.schema.json`
+   - `.github/references/agent-card.schema.json`
+   - `.github/score/repo-manifest.json`
+3. Apply coding standards from `.github/instructions/`.
+
+## Artifact Naming
+
+Use issue-scoped stage folders for all work artifacts:
+
+```
+.stage/ISSUE-<number>/
+  plan.md
+  agent-card.json
+```
+
+## SDLC Progress Block
+
+Paste this into every response when tracking work:
+
+### SDLC Progress -- <ISSUE-ID>
+- [ ] PLAN -- Not Started
+- [ ] CODE -- Not Started
+- [ ] BUILD -- Not Started
+- [ ] TEST -- Not Started
+- [ ] RELEASE -- Not Started
+
+## Governance Rules
+
+- Do not embed large agent/prompt catalogs here.
+- Use an upstream SDD framework (Spec Kit, OpenSpec, BMAD) for workflow orchestration.
+- Keep this file and `.github/instructions/` as the only SCORE-specific overlay.
+- If AGENTS.md and this file conflict, treat AGENTS.md as the canonical project policy and reconcile the files.

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+SCORE canonical assistant policy for this repository.
+
+This file is the shared, runtime-neutral source of behavioral guidance across:
+- Codex (reads AGENTS.md directly)
+- Claude Code (via CLAUDE.md import)
+- Other assistants (via their runtime-specific instructions file)
+
+## Scope
+
+This repository keeps a thin governance overlay only.
+Do not add large local agent or prompt catalogs.
+
+## Core responsibilities
+
+1. Preserve issue-first traceability.
+2. Preserve SCORE contracts:
+   - .github/references/repo-manifest.schema.json
+   - .github/references/agent-card.schema.json
+   - .github/score/repo-manifest.json
+3. Apply coding standards from .github/instructions/.
+
+## Artifact rules
+
+Use issue-scoped artifacts only:
+
+```text
+.stage/ISSUE-<number>/...
+```
+
+Do not create anonymous stage artifacts at repo root.
+
+## SDLC status block
+
+When reporting progress, use:
+
+```markdown
+### SDLC Progress -- <ISSUE-ID>
+- [ ] PLAN -- Not Started
+- [ ] CODE -- Not Started
+- [ ] BUILD -- Not Started
+- [ ] TEST -- Not Started
+- [ ] RELEASE -- Not Started
+```
+
+## Governance constraints
+
+- Keep SCORE policy concise and deterministic.
+- Keep workflow frameworks external (for example Spec Kit or OpenSpec).
+- Keep shared commands in .github/score/repo-manifest.json.

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -21,6 +21,8 @@ Do not add large local agent or prompt catalogs.
    - .github/score/repo-manifest.json
 3. Apply coding standards from .github/instructions/.
 
+Terminology note: .github/references/agent-card.schema.json defines a SCORE work/handoff artifact, not an A2A service-discovery AgentCard.
+
 ## Artifact rules
 
 Use issue-scoped artifacts only:

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -1,0 +1,7 @@
+@AGENTS.md
+
+## Claude Code notes
+
+- Keep Claude-specific additions in this file below the AGENTS import.
+- Prefer .claude/rules/ for path-specific rules when repository complexity grows.
+- Keep this file short; put shared project behavior in AGENTS.md.

--- a/template/scripts/check_markdown_hygiene.py
+++ b/template/scripts/check_markdown_hygiene.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Lightweight markdown hygiene checks for repository-scale governance docs.
+
+Checks:
+- Duplicate markdown files by content hash
+- Broken local markdown links (relative repo paths)
+
+Exit codes:
+- 0: no issues
+- 1: one or more issues found
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+DEFAULT_EXCLUDED_DIRS = {".git", ".venv", "venv", "node_modules", ".mypy_cache", ".pytest_cache"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check markdown hygiene in a repository")
+    parser.add_argument("--root", default=".", help="Repository root path")
+    parser.add_argument(
+        "--include",
+        action="append",
+        default=[".github", "README.md", "profile"],
+        help="Path (file/dir) under root to include; repeatable",
+    )
+    return parser.parse_args()
+
+
+def to_repo_relative(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def gather_markdown_files(root: Path, include_paths: Iterable[str]) -> list[Path]:
+    files: list[Path] = []
+    for include in include_paths:
+        candidate = (root / include).resolve()
+        if not candidate.exists():
+            continue
+        if candidate.is_file() and candidate.suffix.lower() == ".md":
+            files.append(candidate)
+            continue
+        if candidate.is_dir():
+            for path in candidate.rglob("*.md"):
+                if any(part in DEFAULT_EXCLUDED_DIRS for part in path.parts):
+                    continue
+                files.append(path.resolve())
+    unique = sorted(set(files))
+    return unique
+
+
+def sha256_of(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def find_duplicate_markdown(files: list[Path]) -> list[list[Path]]:
+    by_hash: dict[str, list[Path]] = {}
+    for path in files:
+        file_hash = sha256_of(path)
+        by_hash.setdefault(file_hash, []).append(path)
+    return [group for group in by_hash.values() if len(group) > 1]
+
+
+def strip_anchor_and_query(target: str) -> str:
+    no_anchor = target.split("#", 1)[0]
+    no_query = no_anchor.split("?", 1)[0]
+    return no_query
+
+
+def is_external_link(target: str) -> bool:
+    lowered = target.lower()
+    return lowered.startswith(("http://", "https://", "mailto:", "tel:"))
+
+
+def find_broken_local_links(files: list[Path], root: Path) -> list[tuple[Path, str, str]]:
+    issues: list[tuple[Path, str, str]] = []
+    for markdown_file in files:
+        text = markdown_file.read_text(encoding="utf-8")
+        for raw_target in MARKDOWN_LINK_RE.findall(text):
+            target = raw_target.strip()
+            if not target or target.startswith("#") or is_external_link(target):
+                continue
+
+            # Template placeholders are examples, not resolvable links.
+            if "{" in target or "}" in target:
+                continue
+
+            normalized = strip_anchor_and_query(target)
+            if not normalized:
+                continue
+
+            # Absolute repo path style: /path/from/repo/root
+            if normalized.startswith("/"):
+                resolved = (root / normalized.lstrip("/")).resolve()
+            else:
+                resolved = (markdown_file.parent / normalized).resolve()
+
+            if not resolved.exists():
+                issues.append((markdown_file, target, to_repo_relative(markdown_file, root)))
+    return issues
+
+
+def print_duplicate_report(duplicates: list[list[Path]], root: Path) -> None:
+    if not duplicates:
+        print("No duplicate markdown files detected.")
+        return
+    print("Duplicate markdown files detected:")
+    for group in duplicates:
+        print("- Duplicate group:")
+        for path in group:
+            print(f"  - {to_repo_relative(path, root)}")
+
+
+def print_broken_link_report(broken: list[tuple[Path, str, str]], root: Path) -> None:
+    if not broken:
+        print("No broken local markdown links detected.")
+        return
+    print("Broken local markdown links detected:")
+    for markdown_file, target, _ in broken:
+        rel = to_repo_relative(markdown_file, root)
+        print(f"- {rel}: {target}")
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+
+    files = gather_markdown_files(root, args.include)
+    if not files:
+        print("No markdown files found for the configured include paths.")
+        return 0
+
+    duplicates = find_duplicate_markdown(files)
+    broken_links = find_broken_local_links(files, root)
+
+    print(f"Scanned {len(files)} markdown files.")
+    print_duplicate_report(duplicates, root)
+    print_broken_link_report(broken_links, root)
+
+    has_issues = bool(duplicates or broken_links)
+    if has_issues:
+        print("Markdown hygiene check failed.")
+        return 1
+
+    print("Markdown hygiene check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Scope

This PR adds the Copier-based distribution layer for the governance overlay.

## Why

Extracted from oversized PR #51 to separate distribution mechanics from governance-core review.

## Dependency

- merge after #54 and #55

## Out of scope

- root governance schemas and manifest
- root docs and hygiene automation

## Validation

- one focused branch/commit slice for template distribution

## Merge Order

1. #54 (core contracts)
2. #55 (instruction pack)
3. #56 (copier template)
4. #57 (docs and hygiene)

## Relationship to original PR

This PR is part of the split of oversized PR #51.