### PR TITLE
feat: move cache file

### DIFF
--- a/.github/workflows/refresh-profile.yml
+++ b/.github/workflows/refresh-profile.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Restore snapshot cache
         uses: actions/cache@v4
         with:
-          path: profile/cache/repo_overview.json
+          path: .cache/repo_overview.json
           key: snapshot-${{ github.run_id }}
           restore-keys: snapshot-
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ __pycache__/
 /.codex
 /profile/cache/bazel_registry_checkout/
 /profile/cache/reference_integration_checkout/
-/profile/cache/repo_overview.json
+/.cache
 /_site/

--- a/docs/repo-overview-tool-design.md
+++ b/docs/repo-overview-tool-design.md
@@ -41,7 +41,7 @@ The snapshot is intentionally renderer-agnostic. It stores neutral values such a
 
 ## Caching Strategy
 
-The default cache file is `profile/cache/repo_overview.json`.
+The default cache file is `.cache/repo_overview.json`.
 
 The cache is used in two ways:
 

--- a/src/generate_repo_overview/README.md
+++ b/src/generate_repo_overview/README.md
@@ -64,7 +64,7 @@ The renderers do not talk to GitHub directly. They only consume normalized data.
 
 The main cache file is:
 
-- `profile/cache/repo_overview.json`
+- `.cache/repo_overview.json`
 
 That file stores a serialized `RepoSnapshot` containing:
 
@@ -125,7 +125,7 @@ For each repository, the snapshot currently stores:
 
 There is only one persistent cache file today:
 
-- `profile/cache/repo_overview.json`
+- `.cache/repo_overview.json`
 
 There is no separate per-repository cache directory and no checked-out repository mirror.
 
@@ -151,7 +151,7 @@ Rendered outputs such as `profile/README.md` and `_site/` are products of the sn
 
 ## Cache Semantics By Layer
 
-- Render-only paths read `profile/cache/repo_overview.json` and do not contact GitHub.
+- Render-only paths read `.cache/repo_overview.json` and do not contact GitHub.
 - Collection paths always contact GitHub for current repository metadata.
 - During collection, some content-derived fields can still be reused from the previous snapshot when the repository content fingerprint (`default_branch_sha`) matches.
 

--- a/src/generate_repo_overview/constants.py
+++ b/src/generate_repo_overview/constants.py
@@ -4,5 +4,5 @@ from pathlib import Path
 
 DEFAULT_OUTPUT = Path("profile/README.md")
 DEFAULT_METRICS_HTML_OUTPUT = Path("_site")
-DEFAULT_CACHE = Path("profile/cache/repo_overview.json")
+DEFAULT_CACHE = Path(".cache/repo_overview.json")
 DEFAULT_TOKEN_ENV = "GITHUB_TOKEN"


### PR DESCRIPTION
Having the cache file in the middle of all the source code was just confusing. Much clearer when it is in an explicit `.cache` dir.