### PR TITLE
fix: remove redundant force-include causing duplicate wheel entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,6 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/generate_repo_overview"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/generate_repo_overview/templates" = "generate_repo_overview/templates"
-"src/generate_repo_overview/profile_readme_config.toml" = "generate_repo_overview/profile_readme_config.toml"
-
 [tool.uv]
 package = true
 


### PR DESCRIPTION
## Why

`uv sync` (and any hatchling wheel build) fails with:

```
ValueError: A second file is being added to the wheel archive at the
same path: `generate_repo_overview/templates/index.js`.

The most likely cause of this is an entry in the
`tool.hatch.build.targets.wheel.force-include` table.
```

The `packages = ["src/generate_repo_overview"]` directive already
recursively includes the entire package tree — templates, `.toml`
config files, and all. The `force-include` section then tries to add
the same files a second time at identical wheel paths, which hatchling
rejects.

## What

Remove the `[tool.hatch.build.targets.wheel.force-include]` section.
The `packages` directive is sufficient and correct; no explicit
`force-include` is needed.

## Changes

- `pyproject.toml`: remove the four-line `force-include` block that
  duplicated `templates/` and `profile_readme_config.toml` already
  covered by the `packages` directive