### PR TITLE
fix: remove duplicate force-include for templates directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dev = [
 packages = ["src/generate_repo_overview"]
 
 [tool.hatch.build.targets.wheel.force-include]
-"src/generate_repo_overview/templates" = "generate_repo_overview/templates"
 "src/generate_repo_overview/profile_readme_config.toml" = "generate_repo_overview/profile_readme_config.toml"
 
 [tool.uv]


### PR DESCRIPTION
## Problem

Installing `generate-repo-overview` as a dependency fails with:

```
ValueError: A second file is being added to the wheel archive at the same path: `generate_repo_overview/templates/index.js`.

The most likely cause of this is an entry in the `tool.hatch.build.targets.wheel.force-include` table.
```

## Root Cause

The `templates` directory is already included via `packages = ["src/generate_repo_overview"]` in `[tool.hatch.build.targets.wheel]`. The additional `force-include` entry for the same path causes hatchling to attempt adding the files a second time.

## Fix

Remove the redundant force-include entry for `src/generate_repo_overview/templates`. The `profile_readme_config.toml` force-include is still needed since `.toml` files may be excluded by default.