### PR TITLE
fix: sort overview table numerically for PRs, issues, and merged columns

### DIFF
--- a/src/generate_repo_overview/_html_index.py
+++ b/src/generate_repo_overview/_html_index.py
@@ -196,9 +196,9 @@ def _overview_row(entry: RepoEntry, org_name: str) -> str:
         f'    <tr data-name="{e(entry.name)}" data-merged="{entry.volatile.merged_prs_30_days}"'
         f' data-issues="{entry.volatile.open_issues}" data-stars="{entry.stars}">\n'
         f"      <td>{name_cell}</td>\n"
-        f'      <td class="text-right" data-tooltip="{e(merged_tip)}">{merged}</td>\n'
-        f'      <td class="text-right" data-tooltip="{e(issues_tip)}">{issues_cell}</td>\n'
-        f'      <td class="text-right" data-tooltip="{e(prs_tip)}">{prs_cell}</td>\n'
+        f'      <td class="text-right" data-sort-value="{entry.volatile.merged_prs_30_days}" data-tooltip="{e(merged_tip)}">{merged}</td>\n'
+        f'      <td class="text-right" data-sort-value="{entry.volatile.open_issues}" data-tooltip="{e(issues_tip)}">{issues_cell}</td>\n'
+        f'      <td class="text-right" data-sort-value="{total_prs}" data-tooltip="{e(prs_tip)}">{prs_cell}</td>\n'
         f'      <td data-tooltip="{e(release_tip)}">{release}</td>\n'
         f'      <td class="text-right" data-tooltip="{e(stars_tip)}">{stars_forks}</td>\n'
         f"    </tr>"


### PR DESCRIPTION
## Why

Clicking the **Open PRs**, **Open Issues**, or **Merged PRs (30d)** column headers in the overview table sorted incorrectly: repos with fire-badge counts (`🔥 12`) and zero-value em-dashes (`—`) appeared at the wrong end of the list.

The JS sort calls `parseFloat(textContent)` to detect numeric columns. `parseFloat("🔥 12")` and `parseFloat("—")` both return `NaN`, so the sort fell back to `localeCompare`. The em-dash (U+2014) sorts lexicographically after ASCII digits, putting zero-PR repos below all non-zero ones instead of at the top.

## What

Add `data-sort-value` attributes with the raw integer values on the three affected `<td>` elements. The sort script already prefers `data-sort-value` over `textContent` when present — this just makes the numeric path unconditional for these cells.

## Changes

- `src/generate_repo_overview/_html_index.py`: add `data-sort-value` to the Merged PRs (30d), Open Issues, and Open PRs cells in `_overview_row`