### PR TITLE
refactor: replace --deep with --clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ values automatically when they are older than 1 hour.
 You can tune this freshness window with `REPO_OVERVIEW_VOLATILE_TTL_MINUTES`
 (default: `60`).
 
-If you need a full deep refresh for every repository, run:
+If you need a full refresh for every repository, run:
 
 ```sh
-uv run generate-repo-overview collect --deep
+uv run generate-repo-overview collect --clean
 ```
 
 If you only want the profile README:

--- a/docs/repo-overview-tool-design.md
+++ b/docs/repo-overview-tool-design.md
@@ -85,7 +85,7 @@ Built-in commands:
 - `collect --org-config org_config.toml`
   - Sync the cached snapshot from GitHub and write it to disk.
   - Requires `--org-config` pointing to a TOML file with organization-specific settings.
-  - Use `--deep` to force a full refresh for every repository instead of reusing cached signals for unchanged ones.
+  - Use `--clean` to delete the cache and force a full refresh for every repository.
 - `render-overview`
   - Render the profile README from an existing snapshot.
 - `render-details`

--- a/src/generate_repo_overview/README.md
+++ b/src/generate_repo_overview/README.md
@@ -169,7 +169,7 @@ while deep content signals remain cached.
 
 Set `REPO_OVERVIEW_VOLATILE_TTL_MINUTES` to adjust this freshness window.
 
-Use `collect --deep` when you need a full deep refresh for every repository.
+Use `collect --clean` to delete the cache and force a full refresh for every repository.
 
 This is why cached rendering is fast, while live collection is incremental rather than “download everything again.”
 

--- a/src/generate_repo_overview/cli.py
+++ b/src/generate_repo_overview/cli.py
@@ -77,10 +77,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Environment variable that contains the GitHub token",
     )
     collect_parser.add_argument(
-        "--deep",
+        "--clean",
         action="store_true",
         help=(
-            "Force a deep refresh for every repository. "
+            "Delete the cache before collecting, forcing a full refresh for every repository. "
             "By default, unchanged repositories reuse cached detailed signals."
         ),
     )
@@ -152,11 +152,12 @@ def run_collect(args: argparse.Namespace) -> int:
         config = load_org_config(args.org_config)
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
+    if args.clean and args.cache.exists():
+        args.cache.unlink()
     collect_snapshot(
         config=config,
         token_env=args.token_env,
         cache_path=args.cache,
-        reuse_unchanged_repositories=not args.deep,
         status_prefix="repo-overview",
     )
     return 0

--- a/src/generate_repo_overview/collector/__init__.py
+++ b/src/generate_repo_overview/collector/__init__.py
@@ -124,14 +124,14 @@ def collect_snapshot(
     config: OrgConfig,
     token_env: str = DEFAULT_TOKEN_ENV,
     cache_path: Path | None = DEFAULT_CACHE,
-    reuse_unchanged_repositories: bool = False,
     status_prefix: str = "repo-overview",
 ) -> RepoSnapshot:
-    """Collect a fresh snapshot from GitHub, optionally reusing cached data.
+    """Collect a fresh snapshot from GitHub, reusing unchanged repository data from cache.
 
     Loads the existing snapshot from *cache_path* for incremental reuse.
     Invalidates the content cache when workflow signal definitions in
     *config* differ from the cached snapshot.
+    Delete the cache file before calling to force a full refresh (see ``--clean``).
     """
     try:
         from github import Auth, Github
@@ -175,7 +175,6 @@ def collect_snapshot(
         repos = fetch_repositories(
             organization,
             existing_snapshot=existing_snapshot,
-            reuse_unchanged_repositories=reuse_unchanged_repositories,
             github_token=token,
             status_prefix=status_prefix,
             config=config,
@@ -257,7 +256,6 @@ def fetch_repositories(
     organization: OrganizationLike,
     existing_snapshot: RepoSnapshot | None = None,
     *,
-    reuse_unchanged_repositories: bool = False,
     github_token: str | None = None,
     status_prefix: str = "repo-overview",
     config: OrgConfig | None = None,
@@ -392,7 +390,6 @@ def fetch_repositories(
                 referenced_by_reference_integration=(
                     repository_name in reference_integration_repository_names
                 ),
-                reuse_cached_entry_when_unchanged=reuse_unchanged_repositories,
                 workflow_signals=config.workflow_signals,
             )
             futures[future] = (index, repository_name)

--- a/src/generate_repo_overview/collector/repo_entry.py
+++ b/src/generate_repo_overview/collector/repo_entry.py
@@ -69,7 +69,6 @@ def collect_repository_entry(
     bazel_registry_metadata: RegistrySignalsPayload | None,
     cached_entry: RepoEntry | None,
     referenced_by_reference_integration: bool = False,
-    reuse_cached_entry_when_unchanged: bool = False,
     workflow_signals: tuple[WorkflowSignal, ...] = (),
 ) -> RepoEntry:
     fast_entry = maybe_collect_repository_entry_fast_path(
@@ -79,7 +78,6 @@ def collect_repository_entry(
         bazel_registry_metadata=bazel_registry_metadata,
         referenced_by_reference_integration=referenced_by_reference_integration,
         cached_entry=cached_entry,
-        reuse_cached_entry_when_unchanged=reuse_cached_entry_when_unchanged,
     )
     if fast_entry is not None:
         return fast_entry
@@ -103,7 +101,6 @@ def maybe_collect_repository_entry_fast_path(
     bazel_registry_metadata: RegistrySignalsPayload | None,
     referenced_by_reference_integration: bool,
     cached_entry: RepoEntry | None,
-    reuse_cached_entry_when_unchanged: bool,
 ) -> RepoEntry | None:
     """Attempt a fast collection path that avoids deep content inspection.
 
@@ -117,7 +114,7 @@ def maybe_collect_repository_entry_fast_path(
         default_branch_sha=default_branch_sha,
     )
 
-    if not (reuse_cached_entry_when_unchanged and cache_matches_default_branch):
+    if not cache_matches_default_branch:
         return None
 
     assert cached_entry is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,8 @@ def test_collect_help_does_not_expose_refresh_flag(
 
     assert exc_info.value.code == 0
     assert "--refresh" not in captured.out
-    assert "--deep" in captured.out
+    assert "--deep" not in captured.out
+    assert "--clean" in captured.out
 
 
 def test_render_overview_help_shows_expected_args(

--- a/tests/test_repo_overview.py
+++ b/tests/test_repo_overview.py
@@ -386,7 +386,6 @@ def test_collect_repository_entry_reuses_cached_details_when_unchanged() -> None
         },
         cached_entry=cached_entry,
         referenced_by_reference_integration=True,
-        reuse_cached_entry_when_unchanged=True,
     )
 
     assert entry == RepoEntry(
@@ -482,7 +481,6 @@ def test_collect_repository_entry_does_not_reuse_cached_registry_when_metadata_m
         custom_properties={},
         bazel_registry_metadata=None,
         cached_entry=cached_entry,
-        reuse_cached_entry_when_unchanged=True,
     )
 
     assert entry.registry == RegistrySignals()
@@ -575,7 +573,6 @@ def test_collect_repository_entry_refreshes_stale_volatile_metrics_without_tree_
         custom_properties={},
         bazel_registry_metadata=None,
         cached_entry=cached_entry,
-        reuse_cached_entry_when_unchanged=True,
     )
 
     assert repo.tree_calls == 1


### PR DESCRIPTION
## Why

`collect --deep` claimed to force a "deep refresh" but its actual effect was deleting the snapshot cache and re-collecting everything from scratch. The name described the mechanism (crawl deeply), not the intent (start clean). Users had to read the implementation to understand what it actually did.

Additionally, `reuse_unchanged_repositories` was a boolean threaded through four layers of the call stack (`collect_snapshot` → `fetch_repositories` → `collect_repository_entry` → `maybe_collect_repository_entry_fast_path`) purely to support `--deep`. With the new design, deleting the cache before collection makes the parameter unnecessary — an empty cache naturally causes every repo to go through the slow path.

## What

Rename `--deep` to `--clean`. The CLI now deletes the cache file before collecting when `--clean` is passed. The `reuse_unchanged_repositories` parameter is removed from the entire call chain and `maybe_collect_repository_entry_fast_path` is simplified accordingly.

## Changes

- `cli.py` — `--deep` → `--clean`, add `args.cache.unlink()` before collect, drop `reuse_unchanged_repositories` kwarg
- `collector/__init__.py` — remove `reuse_unchanged_repositories` from `collect_snapshot` and `fetch_repositories`
- `collector/repo_entry.py` — remove `reuse_cached_entry_when_unchanged` from `collect_repository_entry` and `maybe_collect_repository_entry_fast_path`, simplify guard to `if not cache_matches_default_branch`
- `README.md`, `docs/repo-overview-tool-design.md`, `src/.../README.md` — update usage examples
- `tests/test_cli.py` — assert `--clean` present, `--deep` absent
- `tests/test_repo_overview.py` — remove `reuse_cached_entry_when_unchanged=True` from call sites