### PR TITLE
feat: bazel lockfile status check and display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ __pycache__/
 /.codex
 /profile/cache/bazel_registry_checkout/
 /profile/cache/reference_integration_checkout/
-/.cache/repo_checkouts/
 /.cache
 /_site/

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 /.codex
 /profile/cache/bazel_registry_checkout/
 /profile/cache/reference_integration_checkout/
+/.cache/repo_checkouts/
 /.cache
 /_site/

--- a/src/generate_repo_overview/_html_common.py
+++ b/src/generate_repo_overview/_html_common.py
@@ -18,14 +18,6 @@ BAZEL_ICON = (
     ' alt="Bazel" class="icon-bazel">'
 )
 
-BAZEL_LOCKFILE_OK_ICON = (
-    '<span title="bazel mod deps --lockfile_mode=error passed"'
-    ' class="icon-lockfile">&#x1F512;</span>'
-)
-BAZEL_LOCKFILE_FAIL_ICON = (
-    '<span title="bazel mod deps --lockfile_mode=error failed"'
-    ' class="icon-lockfile icon-lockfile-fail">&#x1F513;</span>'
-)
 
 GITHUB_ICON = (
     '<svg viewBox="0 0 16 16" fill="currentColor">'

--- a/src/generate_repo_overview/_html_common.py
+++ b/src/generate_repo_overview/_html_common.py
@@ -18,6 +18,15 @@ BAZEL_ICON = (
     ' alt="Bazel" class="icon-bazel">'
 )
 
+BAZEL_LOCKFILE_OK_ICON = (
+    '<span title="bazel mod deps --lockfile_mode=error passed"'
+    ' class="icon-lockfile">&#x1F512;</span>'
+)
+BAZEL_LOCKFILE_FAIL_ICON = (
+    '<span title="bazel mod deps --lockfile_mode=error failed"'
+    ' class="icon-lockfile icon-lockfile-fail">&#x1F513;</span>'
+)
+
 GITHUB_ICON = (
     '<svg viewBox="0 0 16 16" fill="currentColor">'
     '<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17'
@@ -64,7 +73,7 @@ def language_badge(lang: str | None) -> str:
 
 
 def repo_name_cell(entry: RepoEntry, org_name: str, *, bazel_icon: bool = True) -> str:
-    detail_url = f"{e(entry.name)}/"
+    detail_url = f"{e(entry.name)}/index.html"
     github_url = f"https://github.com/{org_name}/{entry.name}"
     title_attr = f' title="{e(entry.description)}"' if entry.description else ""
     cell = f'<a href="{detail_url}"{title_attr}>{e(entry.name)}</a>'

--- a/src/generate_repo_overview/_html_detail.py
+++ b/src/generate_repo_overview/_html_detail.py
@@ -273,8 +273,8 @@ def _render_lockfile_error_section(entry: RepoEntry) -> str:
         )
     elif c.bazel_lockfile_status == LockfileStatus.TIMEOUT:
         body = "<p>Bazel lockfile check timed out.</p>"
-    elif c.bazel_lockfile_error:
-        body = f'<pre class="lockfile-error">{e(c.bazel_lockfile_error)}</pre>'
+    elif c.bazel_lockfile_error_output:
+        body = f'<pre class="lockfile-error">{e(c.bazel_lockfile_error_output)}</pre>'
     else:
         return ""
     return (

--- a/src/generate_repo_overview/_html_detail.py
+++ b/src/generate_repo_overview/_html_detail.py
@@ -264,15 +264,22 @@ def _render_tooling_section(entry: RepoEntry, snapshot: RepoSnapshot) -> str:
 
 
 def _render_lockfile_error_section(entry: RepoEntry) -> str:
-    if not entry.content.bazel_lockfile_error:
+    c = entry.content
+    if c.bazel_lockfile_exists is False:
+        body = (
+            '<p>No <code>MODULE.bazel.lock</code> file found. '
+            "Run <code>bazel mod deps</code> to generate it.</p>"
+        )
+    elif c.bazel_lockfile_error:
+        body = f'<pre class="lockfile-error">{e(c.bazel_lockfile_error)}</pre>'
+    else:
         return ""
-    error_text = e(entry.content.bazel_lockfile_error)
     return (
         '<section class="detail-section" id="lockfile-error">\n'
         '  <div class="section-header">'
-        '<span class="section-title">&#x1F513; Bazel Lockfile Error</span>'
+        '<span class="section-title">Bazel Lockfile</span>'
         "</div>\n"
-        f'  <div class="detail-body"><pre class="lockfile-error">{error_text}</pre></div>\n'
+        f"  <div class=\"detail-body\">{body}</div>\n"
         "</section>\n\n"
     )
 

--- a/src/generate_repo_overview/_html_detail.py
+++ b/src/generate_repo_overview/_html_detail.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from ._html_common import BAZEL_ICON, CSS, GITHUB_ICON, e, language_badge, version_badge
 from .metrics_report import tracked_dep_label
+from .models import LockfileStatus
 
 if TYPE_CHECKING:
     from .models import RepoEntry, RepoSnapshot
@@ -265,11 +266,13 @@ def _render_tooling_section(entry: RepoEntry, snapshot: RepoSnapshot) -> str:
 
 def _render_lockfile_error_section(entry: RepoEntry) -> str:
     c = entry.content
-    if c.bazel_lockfile_exists is False:
+    if c.bazel_lockfile_status == LockfileStatus.MISSING:
         body = (
             '<p>No <code>MODULE.bazel.lock</code> file found. '
             "Run <code>bazel mod deps</code> to generate it.</p>"
         )
+    elif c.bazel_lockfile_status == LockfileStatus.TIMEOUT:
+        body = "<p>Bazel lockfile check timed out.</p>"
     elif c.bazel_lockfile_error:
         body = f'<pre class="lockfile-error">{e(c.bazel_lockfile_error)}</pre>'
     else:

--- a/src/generate_repo_overview/_html_detail.py
+++ b/src/generate_repo_overview/_html_detail.py
@@ -29,6 +29,7 @@ def render_detail_page(
         + _render_release_section(entry)
         + _render_dep_diff_section(entry)
         + _render_tooling_section(entry, snapshot)
+        + _render_lockfile_error_section(entry)
         + _render_ownership_section(entry)
         + _render_versions_section(entry, snapshot, max_bazel, latest_dep_versions)
         + _render_footer(snapshot)
@@ -258,6 +259,20 @@ def _render_tooling_section(entry: RepoEntry, snapshot: RepoSnapshot) -> str:
         '<section class="detail-section">\n'
         '  <div class="section-header"><span class="section-title">Build &amp; Tooling</span></div>\n'
         f'  <div class="detail-body"><div class="signal-grid">\n{items}\n  </div></div>\n'
+        "</section>\n\n"
+    )
+
+
+def _render_lockfile_error_section(entry: RepoEntry) -> str:
+    if not entry.content.bazel_lockfile_error:
+        return ""
+    error_text = e(entry.content.bazel_lockfile_error)
+    return (
+        '<section class="detail-section" id="lockfile-error">\n'
+        '  <div class="section-header">'
+        '<span class="section-title">&#x1F513; Bazel Lockfile Error</span>'
+        "</div>\n"
+        f'  <div class="detail-body"><pre class="lockfile-error">{error_text}</pre></div>\n'
         "</section>\n\n"
     )
 

--- a/src/generate_repo_overview/_html_index.py
+++ b/src/generate_repo_overview/_html_index.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 
 from ._html_common import (
     BAZEL_ICON,
-    BAZEL_LOCKFILE_FAIL_ICON,
-    BAZEL_LOCKFILE_OK_ICON,
     CSS,
     e,
     language_badge,
@@ -551,6 +549,25 @@ def _render_automation_sections(
     return "".join(parts)
 
 
+def _lockfile_cell(entry: RepoEntry) -> tuple[str, str]:
+    c = entry.content
+    if c.bazel_lockfile_ok is True:
+        return '<span class="badge green">ok</span>', "The Bazel lockfile is up to date (bazel mod deps --lockfile_mode=error passes)."
+    if c.bazel_lockfile_exists is False:
+        url = f"{e(entry.name)}/index.html#lockfile-error"
+        cell = f'<span class="badge yellow"><a href="{url}" class="lockfile-error-link">missing</a></span>'
+        return cell, "MODULE.bazel.lock does not exist — click for details."
+    if c.bazel_lockfile_ok is False and c.bazel_lockfile_error:
+        url = f"{e(entry.name)}/index.html#lockfile-error"
+        cell = f'<span class="badge red"><a href="{url}" class="lockfile-error-link">error</a></span>'
+        return cell, "The Bazel lockfile is out of date — click to see the error."
+    if c.bazel_lockfile_ok is False:
+        return '<span class="badge red">error</span>', "The Bazel lockfile check failed."
+    if c.has_bazel_module:
+        return '<span class="text-muted">n/a</span>', "Lockfile status not yet collected."
+    return '<span class="text-muted">—</span>', "Not a Bazel module repository."
+
+
 def _automation_row(
     entry: RepoEntry, org_name: str, signal_labels: tuple[str, ...]
 ) -> str:
@@ -567,20 +584,7 @@ def _automation_row(
             return '<span class="badge green">yes</span>'
         return '<span class="text-muted">no</span>'
 
-    if c.bazel_lockfile_ok is True:
-        lockfile_cell = f'<span class="badge green">{BAZEL_LOCKFILE_OK_ICON}</span>'
-        lockfile_tip = "The Bazel lockfile is up to date (bazel mod deps --lockfile_mode=error passes)."
-    elif c.bazel_lockfile_ok is False:
-        detail_url = f"{e(entry.name)}/index.html#lockfile-error"
-        lockfile_cell = (
-            f'<span class="badge red">'
-            f'<a href="{detail_url}" class="lockfile-error-link">'
-            f"{BAZEL_LOCKFILE_FAIL_ICON} ❌</a></span>"
-        )
-        lockfile_tip = "The Bazel lockfile is out of date — click to see the error."
-    else:
-        lockfile_cell = '<span class="text-muted">—</span>'
-        lockfile_tip = "Lockfile status unknown (not a Bazel repo or bazel not available)."
+    lockfile_cell, lockfile_tip = _lockfile_cell(entry)
 
     tips = {
         "bazel": "This repository uses Bazel as its build system."

--- a/src/generate_repo_overview/_html_index.py
+++ b/src/generate_repo_overview/_html_index.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 from ._html_common import (
     BAZEL_ICON,
+    BAZEL_LOCKFILE_FAIL_ICON,
+    BAZEL_LOCKFILE_OK_ICON,
     CSS,
     e,
     language_badge,
@@ -534,6 +536,7 @@ def _render_automation_sections(
             f'      <th data-sort="name">Repository <span class="sort-arrow"></span></th>\n'
             f'      <th data-sort="lang">Language <span class="sort-arrow"></span></th>\n'
             f'      <th data-sort="bazel" class="text-center" title="Whether this repository uses Bazel as its build system.">Bazel <span class="sort-arrow"></span></th>\n'
+            f'      <th data-sort="lockfile" class="text-center" title="Whether `bazel mod deps --lockfile_mode=error` passes — the Bazel lockfile is up to date.">Lockfile <span class="sort-arrow"></span></th>\n'
             f'      <th data-sort="gitlint" class="text-center" title="Whether this repository enforces commit message formatting rules (gitlint).">Gitlint <span class="sort-arrow"></span></th>\n'
             f'      <th data-sort="pyproject" class="text-center" title="Whether this repository has a pyproject.toml — the standard configuration file for Python projects.">Pyproject <span class="sort-arrow"></span></th>\n'
             f'      <th data-sort="precommit" class="text-center" title="Whether this repository runs automated checks (formatting, linting, etc.) before each commit is accepted.">Pre-commit <span class="sort-arrow"></span></th>\n'
@@ -563,6 +566,21 @@ def _automation_row(
         if val:
             return '<span class="badge green">yes</span>'
         return '<span class="text-muted">no</span>'
+
+    if c.bazel_lockfile_ok is True:
+        lockfile_cell = f'<span class="badge green">{BAZEL_LOCKFILE_OK_ICON}</span>'
+        lockfile_tip = "The Bazel lockfile is up to date (bazel mod deps --lockfile_mode=error passes)."
+    elif c.bazel_lockfile_ok is False:
+        detail_url = f"{e(entry.name)}/index.html#lockfile-error"
+        lockfile_cell = (
+            f'<span class="badge red">'
+            f'<a href="{detail_url}" class="lockfile-error-link">'
+            f"{BAZEL_LOCKFILE_FAIL_ICON} ❌</a></span>"
+        )
+        lockfile_tip = "The Bazel lockfile is out of date — click to see the error."
+    else:
+        lockfile_cell = '<span class="text-muted">—</span>'
+        lockfile_tip = "Lockfile status unknown (not a Bazel repo or bazel not available)."
 
     tips = {
         "bazel": "This repository uses Bazel as its build system."
@@ -608,6 +626,7 @@ def _automation_row(
         f"      <td>{name_cell}</td>\n"
         f'      <td data-tooltip="{e(lang_tip)}">{lang_cell}</td>\n'
         f'      <td class="text-center" data-tooltip="{e(tips["bazel"])}">{_presence(c.is_bazel_repo, BAZEL_ICON)}</td>\n'
+        f'      <td class="text-center" data-tooltip="{e(lockfile_tip)}">{lockfile_cell}</td>\n'
         f'      <td class="text-center" data-tooltip="{e(tips["gitlint"])}">{_presence(c.has_gitlint_config, "\U0001f50d")}</td>\n'
         f'      <td class="text-center" data-tooltip="{e(tips["pyproject"])}">{_presence(c.has_pyproject_toml, "\U0001f40d")}</td>\n'
         f'      <td class="text-center" data-tooltip="{e(tips["precommit"])}">{_presence(c.has_pre_commit_config, "\U0001fa9d")}</td>\n'

--- a/src/generate_repo_overview/_html_index.py
+++ b/src/generate_repo_overview/_html_index.py
@@ -21,6 +21,7 @@ from .metrics_report import (
     parse_version_key,
     tracked_dep_label,
 )
+from .models import LockfileStatus
 
 if TYPE_CHECKING:
     from .models import RepoEntry, RepoSnapshot, TrackedDep
@@ -550,20 +551,21 @@ def _render_automation_sections(
 
 
 def _lockfile_cell(entry: RepoEntry) -> tuple[str, str]:
-    c = entry.content
-    if c.bazel_lockfile_ok is True:
-        return '<span class="badge green">ok</span>', "The Bazel lockfile is up to date (bazel mod deps --lockfile_mode=error passes)."
-    if c.bazel_lockfile_exists is False:
-        url = f"{e(entry.name)}/index.html#lockfile-error"
+    status = entry.content.bazel_lockfile_status
+    has_error = bool(entry.content.bazel_lockfile_error)
+    url = f"{e(entry.name)}/index.html#lockfile-error"
+
+    if status == LockfileStatus.OK:
+        return '<span class="badge green">ok</span>', "The Bazel lockfile is up to date."
+    if status == LockfileStatus.MISSING:
         cell = f'<span class="badge yellow"><a href="{url}" class="lockfile-error-link">missing</a></span>'
         return cell, "MODULE.bazel.lock does not exist — click for details."
-    if c.bazel_lockfile_ok is False and c.bazel_lockfile_error:
-        url = f"{e(entry.name)}/index.html#lockfile-error"
-        cell = f'<span class="badge red"><a href="{url}" class="lockfile-error-link">error</a></span>'
-        return cell, "The Bazel lockfile is out of date — click to see the error."
-    if c.bazel_lockfile_ok is False:
-        return '<span class="badge red">error</span>', "The Bazel lockfile check failed."
-    if c.has_bazel_module:
+    if status == LockfileStatus.ERROR:
+        link_text = f'<a href="{url}" class="lockfile-error-link">error</a>' if has_error else "error"
+        return f'<span class="badge red">{link_text}</span>', "The Bazel lockfile is out of date — click to see the error."
+    if status == LockfileStatus.TIMEOUT:
+        return '<span class="badge yellow">timeout</span>', "Bazel lockfile check timed out."
+    if entry.content.has_bazel_module:
         return '<span class="text-muted">n/a</span>', "Lockfile status not yet collected."
     return '<span class="text-muted">—</span>', "Not a Bazel module repository."
 

--- a/src/generate_repo_overview/_html_index.py
+++ b/src/generate_repo_overview/_html_index.py
@@ -552,7 +552,7 @@ def _render_automation_sections(
 
 def _lockfile_cell(entry: RepoEntry) -> tuple[str, str]:
     status = entry.content.bazel_lockfile_status
-    has_error = bool(entry.content.bazel_lockfile_error)
+    has_error = bool(entry.content.bazel_lockfile_error_output)
     url = f"{e(entry.name)}/index.html#lockfile-error"
 
     if status == LockfileStatus.OK:

--- a/src/generate_repo_overview/collector/__init__.py
+++ b/src/generate_repo_overview/collector/__init__.py
@@ -391,6 +391,7 @@ def fetch_repositories(
                     repository_name in reference_integration_repository_names
                 ),
                 workflow_signals=config.workflow_signals,
+                github_token=github_token,
             )
             futures[future] = (index, repository_name)
 

--- a/src/generate_repo_overview/collector/repo_entry.py
+++ b/src/generate_repo_overview/collector/repo_entry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import replace
 from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from generate_repo_overview.models import (
@@ -16,13 +17,17 @@ from generate_repo_overview.models import (
     WorkflowSignal,
 )
 
+from .git_checkout import sync_repository_checkout
 from .signal_detection import (
     DeepContentPayload,
     detect_all_bazel_deps,
+    detect_bazel_lockfile_ok,
     detect_bazel_version,
     fetch_repository_tree_paths,
     inspect_repository_content_slow,
 )
+
+REPO_CHECKOUTS_BASE = Path(".cache/repo_checkouts")
 
 if TYPE_CHECKING:
     from .registry_metadata import RegistrySignalsPayload
@@ -70,6 +75,7 @@ def collect_repository_entry(
     cached_entry: RepoEntry | None,
     referenced_by_reference_integration: bool = False,
     workflow_signals: tuple[WorkflowSignal, ...] = (),
+    github_token: str | None = None,
 ) -> RepoEntry:
     fast_entry = maybe_collect_repository_entry_fast_path(
         repository_name=repository_name,
@@ -90,6 +96,7 @@ def collect_repository_entry(
         referenced_by_reference_integration=referenced_by_reference_integration,
         cached_entry=cached_entry,
         workflow_signals=workflow_signals,
+        github_token=github_token,
     )
 
 
@@ -172,6 +179,7 @@ def collect_repository_entry_slow_path(
     referenced_by_reference_integration: bool,
     cached_entry: RepoEntry | None,
     workflow_signals: tuple[WorkflowSignal, ...] = (),
+    github_token: str | None = None,
 ) -> RepoEntry:
     """Collect a repository entry with deep content inspection.
 
@@ -193,6 +201,15 @@ def collect_repository_entry_slow_path(
             ref=default_branch_sha,
             workflow_signals=workflow_signals,
         )
+        if content_signals["has_bazel_module"]:
+            lockfile_ok, lockfile_error = _detect_lockfile_ok_for_repo(
+                repository_name=repository_name,
+                repository=repository,
+                default_branch=default_branch,
+                github_token=github_token,
+            )
+            content_signals["bazel_lockfile_ok"] = lockfile_ok
+            content_signals["bazel_lockfile_error"] = lockfile_error
     else:
         content_signals = cached_content_signals
     content_signals["referenced_by_reference_integration"] = (
@@ -218,6 +235,28 @@ def collect_repository_entry_slow_path(
         stars=getattr(repository, "stargazers_count", 0) or 0,
         forks=getattr(repository, "forks_count", 0) or 0,
     )
+
+
+def _detect_lockfile_ok_for_repo(
+    *,
+    repository_name: str,
+    repository: Any,
+    default_branch: str | None,
+    github_token: str | None,
+) -> tuple[bool | None, str | None]:
+    clone_url = cast("str | None", getattr(repository, "clone_url", None))
+    if clone_url is None or default_branch is None:
+        return None, None
+    checkout_path = REPO_CHECKOUTS_BASE / repository_name
+    synced = sync_repository_checkout(
+        clone_url=clone_url,
+        default_branch=default_branch,
+        github_token=github_token,
+        checkout_path=checkout_path,
+    )
+    if synced is None:
+        return None, None
+    return detect_bazel_lockfile_ok(synced)
 
 
 def collect_volatile_metrics(
@@ -300,6 +339,7 @@ def cached_signals_for_repository(
     assert cached_entry is not None
     return {
         "is_bazel_repo": cached_entry.content.is_bazel_repo,
+        "has_bazel_module": cached_entry.content.has_bazel_module,
         "bazel_version": cached_entry.content.bazel_version,
         "codeowners": cached_entry.content.codeowners,
         "referenced_by_reference_integration": (
@@ -314,6 +354,8 @@ def cached_signals_for_repository(
         "has_coverage_config": cached_entry.content.has_coverage_config,
         "top_languages": cached_entry.content.top_languages,
         "bazel_deps": cached_entry.content.bazel_deps,
+        "bazel_lockfile_ok": cached_entry.content.bazel_lockfile_ok,
+        "bazel_lockfile_error": cached_entry.content.bazel_lockfile_error,
     }
 
 
@@ -403,6 +445,7 @@ def build_repo_entry(
         default_branch_sha=default_branch_sha,
         content=DeepContentSignals(
             is_bazel_repo=content_signals["is_bazel_repo"],
+            has_bazel_module=content_signals["has_bazel_module"],
             bazel_version=content_signals["bazel_version"],
             codeowners=content_signals["codeowners"],
             referenced_by_reference_integration=bool(
@@ -419,6 +462,8 @@ def build_repo_entry(
             has_coverage_config=content_signals["has_coverage_config"],
             top_languages=content_signals.get("top_languages", ()),
             bazel_deps=content_signals.get("bazel_deps", ()),
+            bazel_lockfile_ok=content_signals.get("bazel_lockfile_ok"),
+            bazel_lockfile_error=content_signals.get("bazel_lockfile_error"),
         ),
         registry=registry_signals,
         volatile=VolatileMetricsSnapshot(

--- a/src/generate_repo_overview/collector/repo_entry.py
+++ b/src/generate_repo_overview/collector/repo_entry.py
@@ -202,13 +202,14 @@ def collect_repository_entry_slow_path(
             workflow_signals=workflow_signals,
         )
         if content_signals["has_bazel_module"]:
-            lockfile_ok, lockfile_error = _detect_lockfile_ok_for_repo(
+            lockfile_ok, lockfile_exists, lockfile_error = _detect_lockfile_ok_for_repo(
                 repository_name=repository_name,
                 repository=repository,
                 default_branch=default_branch,
                 github_token=github_token,
             )
             content_signals["bazel_lockfile_ok"] = lockfile_ok
+            content_signals["bazel_lockfile_exists"] = lockfile_exists
             content_signals["bazel_lockfile_error"] = lockfile_error
     else:
         content_signals = cached_content_signals
@@ -243,10 +244,10 @@ def _detect_lockfile_ok_for_repo(
     repository: Any,
     default_branch: str | None,
     github_token: str | None,
-) -> tuple[bool | None, str | None]:
+) -> tuple[bool | None, bool | None, str | None]:
     clone_url = cast("str | None", getattr(repository, "clone_url", None))
     if clone_url is None or default_branch is None:
-        return None, None
+        return None, None, None
     checkout_path = REPO_CHECKOUTS_BASE / repository_name
     synced = sync_repository_checkout(
         clone_url=clone_url,
@@ -255,7 +256,7 @@ def _detect_lockfile_ok_for_repo(
         checkout_path=checkout_path,
     )
     if synced is None:
-        return None, None
+        return None, None, None
     return detect_bazel_lockfile_ok(synced)
 
 
@@ -355,6 +356,7 @@ def cached_signals_for_repository(
         "top_languages": cached_entry.content.top_languages,
         "bazel_deps": cached_entry.content.bazel_deps,
         "bazel_lockfile_ok": cached_entry.content.bazel_lockfile_ok,
+        "bazel_lockfile_exists": cached_entry.content.bazel_lockfile_exists,
         "bazel_lockfile_error": cached_entry.content.bazel_lockfile_error,
     }
 
@@ -463,6 +465,7 @@ def build_repo_entry(
             top_languages=content_signals.get("top_languages", ()),
             bazel_deps=content_signals.get("bazel_deps", ()),
             bazel_lockfile_ok=content_signals.get("bazel_lockfile_ok"),
+            bazel_lockfile_exists=content_signals.get("bazel_lockfile_exists"),
             bazel_lockfile_error=content_signals.get("bazel_lockfile_error"),
         ),
         registry=registry_signals,

--- a/src/generate_repo_overview/collector/repo_entry.py
+++ b/src/generate_repo_overview/collector/repo_entry.py
@@ -210,7 +210,7 @@ def collect_repository_entry_slow_path(
                 github_token=github_token,
             )
             content_signals["bazel_lockfile_status"] = lockfile_status
-            content_signals["bazel_lockfile_error"] = lockfile_error
+            content_signals["bazel_lockfile_error_output"] = lockfile_error
     else:
         content_signals = cached_content_signals
     content_signals["referenced_by_reference_integration"] = (
@@ -356,7 +356,7 @@ def cached_signals_for_repository(
         "top_languages": cached_entry.content.top_languages,
         "bazel_deps": cached_entry.content.bazel_deps,
         "bazel_lockfile_status": cached_entry.content.bazel_lockfile_status,
-        "bazel_lockfile_error": cached_entry.content.bazel_lockfile_error,
+        "bazel_lockfile_error_output": cached_entry.content.bazel_lockfile_error_output,
     }
 
 
@@ -464,7 +464,7 @@ def build_repo_entry(
             top_languages=content_signals.get("top_languages", ()),
             bazel_deps=content_signals.get("bazel_deps", ()),
             bazel_lockfile_status=content_signals.get("bazel_lockfile_status", LockfileStatus.UNKNOWN),
-            bazel_lockfile_error=content_signals.get("bazel_lockfile_error"),
+            bazel_lockfile_error_output=content_signals.get("bazel_lockfile_error_output"),
         ),
         registry=registry_signals,
         volatile=VolatileMetricsSnapshot(

--- a/src/generate_repo_overview/collector/repo_entry.py
+++ b/src/generate_repo_overview/collector/repo_entry.py
@@ -11,6 +11,7 @@ from generate_repo_overview.models import (
     DEFAULT_SUBCATEGORY,
     CustomPropertyValue,
     DeepContentSignals,
+    LockfileStatus,
     RegistrySignals,
     RepoEntry,
     VolatileMetricsSnapshot,
@@ -202,14 +203,13 @@ def collect_repository_entry_slow_path(
             workflow_signals=workflow_signals,
         )
         if content_signals["has_bazel_module"]:
-            lockfile_ok, lockfile_exists, lockfile_error = _detect_lockfile_ok_for_repo(
+            lockfile_status, lockfile_error = _detect_lockfile_ok_for_repo(
                 repository_name=repository_name,
                 repository=repository,
                 default_branch=default_branch,
                 github_token=github_token,
             )
-            content_signals["bazel_lockfile_ok"] = lockfile_ok
-            content_signals["bazel_lockfile_exists"] = lockfile_exists
+            content_signals["bazel_lockfile_status"] = lockfile_status
             content_signals["bazel_lockfile_error"] = lockfile_error
     else:
         content_signals = cached_content_signals
@@ -244,10 +244,10 @@ def _detect_lockfile_ok_for_repo(
     repository: Any,
     default_branch: str | None,
     github_token: str | None,
-) -> tuple[bool | None, bool | None, str | None]:
+) -> tuple[LockfileStatus, str | None]:
     clone_url = cast("str | None", getattr(repository, "clone_url", None))
     if clone_url is None or default_branch is None:
-        return None, None, None
+        return LockfileStatus.UNKNOWN, None
     checkout_path = REPO_CHECKOUTS_BASE / repository_name
     synced = sync_repository_checkout(
         clone_url=clone_url,
@@ -256,7 +256,7 @@ def _detect_lockfile_ok_for_repo(
         checkout_path=checkout_path,
     )
     if synced is None:
-        return None, None, None
+        return LockfileStatus.UNKNOWN, None
     return detect_bazel_lockfile_ok(synced)
 
 
@@ -355,8 +355,7 @@ def cached_signals_for_repository(
         "has_coverage_config": cached_entry.content.has_coverage_config,
         "top_languages": cached_entry.content.top_languages,
         "bazel_deps": cached_entry.content.bazel_deps,
-        "bazel_lockfile_ok": cached_entry.content.bazel_lockfile_ok,
-        "bazel_lockfile_exists": cached_entry.content.bazel_lockfile_exists,
+        "bazel_lockfile_status": cached_entry.content.bazel_lockfile_status,
         "bazel_lockfile_error": cached_entry.content.bazel_lockfile_error,
     }
 
@@ -464,8 +463,7 @@ def build_repo_entry(
             has_coverage_config=content_signals["has_coverage_config"],
             top_languages=content_signals.get("top_languages", ()),
             bazel_deps=content_signals.get("bazel_deps", ()),
-            bazel_lockfile_ok=content_signals.get("bazel_lockfile_ok"),
-            bazel_lockfile_exists=content_signals.get("bazel_lockfile_exists"),
+            bazel_lockfile_status=content_signals.get("bazel_lockfile_status", LockfileStatus.UNKNOWN),
             bazel_lockfile_error=content_signals.get("bazel_lockfile_error"),
         ),
         registry=registry_signals,

--- a/src/generate_repo_overview/collector/signal_detection.py
+++ b/src/generate_repo_overview/collector/signal_detection.py
@@ -27,6 +27,7 @@ class DeepContentPayload(TypedDict):
     top_languages: tuple[str, ...]
     bazel_deps: tuple[tuple[str, str], ...]
     bazel_lockfile_ok: bool | None
+    bazel_lockfile_exists: bool | None
     bazel_lockfile_error: str | None
 
 
@@ -55,16 +56,20 @@ VERSION_PATTERN = re.compile(r'\bversion\s*=\s*"(?P<version>[^"]+)"')
 BAZEL_LOCKFILE_TIMEOUT_SECONDS = 60
 
 
-def detect_bazel_lockfile_ok(checkout_path: Path) -> tuple[bool | None, str | None]:
+def detect_bazel_lockfile_ok(checkout_path: Path) -> tuple[bool | None, bool | None, str | None]:
     """Run `bazel mod deps --lockfile_mode=error` in the checkout.
 
-    Returns (ok, error_output):
-      (True, None)    — lockfile is up to date
-      (False, stderr) — lockfile check failed; stderr contains the error
-      (None, None)    — bazel unavailable or MODULE.bazel missing
+    Returns (ok, lockfile_exists, error_output):
+      (True,  True,  None)    — lockfile exists and is up to date
+      (False, True,  stderr)  — lockfile exists but check failed
+      (False, False, None)    — MODULE.bazel.lock does not exist
+      (None,  None,  None)    — bazel unavailable or MODULE.bazel missing
     """
     if not (checkout_path / "MODULE.bazel").exists():
-        return None, None
+        return None, None, None
+    lockfile_exists = (checkout_path / "MODULE.bazel.lock").exists()
+    if not lockfile_exists:
+        return False, False, None
     try:
         result = subprocess.run(
             ["bazel", "mod", "deps", "--lockfile_mode=error"],
@@ -75,11 +80,13 @@ def detect_bazel_lockfile_ok(checkout_path: Path) -> tuple[bool | None, str | No
             text=True,
             timeout=BAZEL_LOCKFILE_TIMEOUT_SECONDS,
         )
-    except (OSError, subprocess.TimeoutExpired):
-        return None, None
+    except OSError:
+        return None, None, None
+    except subprocess.TimeoutExpired:
+        return None, True, None
     if result.returncode != 0:
-        return False, result.stderr.strip() or None
-    return True, None
+        return False, True, result.stderr.strip() or None
+    return True, True, None
 
 
 def inspect_repository_content_slow(
@@ -137,6 +144,7 @@ def inspect_repository_content_slow(
         ),
         "top_languages": detect_top_languages(repository, n=3),
         "bazel_lockfile_ok": None,
+        "bazel_lockfile_exists": None,
         "bazel_lockfile_error": None,
     }
 
@@ -158,6 +166,7 @@ def default_content_signals() -> DeepContentPayload:
         "has_coverage_config": False,
         "top_languages": (),
         "bazel_lockfile_ok": None,
+        "bazel_lockfile_exists": None,
         "bazel_lockfile_error": None,
     }
 

--- a/src/generate_repo_overview/collector/signal_detection.py
+++ b/src/generate_repo_overview/collector/signal_detection.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 import fnmatch
 import re
+import subprocess
 from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from generate_repo_overview.models import WorkflowSignal
 
 
 class DeepContentPayload(TypedDict):
     is_bazel_repo: bool
+    has_bazel_module: bool
     bazel_version: str | None
     codeowners: tuple[str, ...]
     referenced_by_reference_integration: bool
@@ -22,6 +26,8 @@ class DeepContentPayload(TypedDict):
     has_coverage_config: bool
     top_languages: tuple[str, ...]
     bazel_deps: tuple[tuple[str, str], ...]
+    bazel_lockfile_ok: bool | None
+    bazel_lockfile_error: str | None
 
 
 GITLINT_PATHS = (".gitlint",)
@@ -46,6 +52,36 @@ WORKFLOW_FILE_SUFFIXES = (".yml", ".yaml")
 VERSION_PATTERN = re.compile(r'\bversion\s*=\s*"(?P<version>[^"]+)"')
 
 
+BAZEL_LOCKFILE_TIMEOUT_SECONDS = 60
+
+
+def detect_bazel_lockfile_ok(checkout_path: Path) -> tuple[bool | None, str | None]:
+    """Run `bazel mod deps --lockfile_mode=error` in the checkout.
+
+    Returns (ok, error_output):
+      (True, None)    — lockfile is up to date
+      (False, stderr) — lockfile check failed; stderr contains the error
+      (None, None)    — bazel unavailable or MODULE.bazel missing
+    """
+    if not (checkout_path / "MODULE.bazel").exists():
+        return None, None
+    try:
+        result = subprocess.run(
+            ["bazel", "mod", "deps", "--lockfile_mode=error"],
+            cwd=checkout_path,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=BAZEL_LOCKFILE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None, None
+    if result.returncode != 0:
+        return False, result.stderr.strip() or None
+    return True, None
+
+
 def inspect_repository_content_slow(
     repository: Any,
     *,
@@ -58,6 +94,9 @@ def inspect_repository_content_slow(
 
     return {
         "is_bazel_repo": detect_is_bazel_repo(tree_paths),
+        "has_bazel_module": any(
+            tree_contains_path(tree_paths, p) for p in MODULE_PATHS
+        ),
         "bazel_version": detect_bazel_version(
             repository,
             tree_paths=tree_paths,
@@ -97,12 +136,15 @@ def inspect_repository_content_slow(
             tree_contains_path(tree_paths, path) for path in COVERAGE_PATHS
         ),
         "top_languages": detect_top_languages(repository, n=3),
+        "bazel_lockfile_ok": None,
+        "bazel_lockfile_error": None,
     }
 
 
 def default_content_signals() -> DeepContentPayload:
     return {
         "is_bazel_repo": False,
+        "has_bazel_module": False,
         "bazel_version": None,
         "codeowners": (),
         "bazel_deps": (),
@@ -115,6 +157,8 @@ def default_content_signals() -> DeepContentPayload:
         "matched_workflow_signals": (),
         "has_coverage_config": False,
         "top_languages": (),
+        "bazel_lockfile_ok": None,
+        "bazel_lockfile_error": None,
     }
 
 

--- a/src/generate_repo_overview/collector/signal_detection.py
+++ b/src/generate_repo_overview/collector/signal_detection.py
@@ -29,7 +29,7 @@ class DeepContentPayload(TypedDict):
     top_languages: tuple[str, ...]
     bazel_deps: tuple[tuple[str, str], ...]
     bazel_lockfile_status: LockfileStatus
-    bazel_lockfile_error: str | None
+    bazel_lockfile_error_output: str | None
 
 
 GITLINT_PATHS = (".gitlint",)
@@ -145,7 +145,7 @@ def inspect_repository_content_slow(
         ),
         "top_languages": detect_top_languages(repository, n=3),
         "bazel_lockfile_status": LockfileStatus.UNKNOWN,
-        "bazel_lockfile_error": None,
+        "bazel_lockfile_error_output": None,
     }
 
 
@@ -166,7 +166,7 @@ def default_content_signals() -> DeepContentPayload:
         "has_coverage_config": False,
         "top_languages": (),
         "bazel_lockfile_status": LockfileStatus.UNKNOWN,
-        "bazel_lockfile_error": None,
+        "bazel_lockfile_error_output": None,
     }
 
 

--- a/src/generate_repo_overview/collector/signal_detection.py
+++ b/src/generate_repo_overview/collector/signal_detection.py
@@ -5,6 +5,8 @@ import re
 import subprocess
 from typing import TYPE_CHECKING, Any, TypedDict
 
+from generate_repo_overview.models import LockfileStatus
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -26,8 +28,7 @@ class DeepContentPayload(TypedDict):
     has_coverage_config: bool
     top_languages: tuple[str, ...]
     bazel_deps: tuple[tuple[str, str], ...]
-    bazel_lockfile_ok: bool | None
-    bazel_lockfile_exists: bool | None
+    bazel_lockfile_status: LockfileStatus
     bazel_lockfile_error: str | None
 
 
@@ -56,20 +57,20 @@ VERSION_PATTERN = re.compile(r'\bversion\s*=\s*"(?P<version>[^"]+)"')
 BAZEL_LOCKFILE_TIMEOUT_SECONDS = 60
 
 
-def detect_bazel_lockfile_ok(checkout_path: Path) -> tuple[bool | None, bool | None, str | None]:
+def detect_bazel_lockfile_ok(checkout_path: Path) -> tuple[LockfileStatus, str | None]:
     """Run `bazel mod deps --lockfile_mode=error` in the checkout.
 
-    Returns (ok, lockfile_exists, error_output):
-      (True,  True,  None)    — lockfile exists and is up to date
-      (False, True,  stderr)  — lockfile exists but check failed
-      (False, False, None)    — MODULE.bazel.lock does not exist
-      (None,  None,  None)    — bazel unavailable or MODULE.bazel missing
+    Returns (status, error_output):
+      (OK,      None)    — lockfile exists and is up to date
+      (ERROR,   stderr)  — lockfile check failed
+      (MISSING, None)    — MODULE.bazel.lock does not exist
+      (TIMEOUT, None)    — bazel timed out
+      (UNKNOWN, None)    — bazel unavailable or MODULE.bazel missing
     """
     if not (checkout_path / "MODULE.bazel").exists():
-        return None, None, None
-    lockfile_exists = (checkout_path / "MODULE.bazel.lock").exists()
-    if not lockfile_exists:
-        return False, False, None
+        return LockfileStatus.UNKNOWN, None
+    if not (checkout_path / "MODULE.bazel.lock").exists():
+        return LockfileStatus.MISSING, None
     try:
         result = subprocess.run(
             ["bazel", "mod", "deps", "--lockfile_mode=error"],
@@ -81,12 +82,12 @@ def detect_bazel_lockfile_ok(checkout_path: Path) -> tuple[bool | None, bool | N
             timeout=BAZEL_LOCKFILE_TIMEOUT_SECONDS,
         )
     except OSError:
-        return None, None, None
+        return LockfileStatus.UNKNOWN, None
     except subprocess.TimeoutExpired:
-        return None, True, None
+        return LockfileStatus.TIMEOUT, None
     if result.returncode != 0:
-        return False, True, result.stderr.strip() or None
-    return True, True, None
+        return LockfileStatus.ERROR, result.stderr.strip() or None
+    return LockfileStatus.OK, None
 
 
 def inspect_repository_content_slow(
@@ -143,8 +144,7 @@ def inspect_repository_content_slow(
             tree_contains_path(tree_paths, path) for path in COVERAGE_PATHS
         ),
         "top_languages": detect_top_languages(repository, n=3),
-        "bazel_lockfile_ok": None,
-        "bazel_lockfile_exists": None,
+        "bazel_lockfile_status": LockfileStatus.UNKNOWN,
         "bazel_lockfile_error": None,
     }
 
@@ -165,8 +165,7 @@ def default_content_signals() -> DeepContentPayload:
         "matched_workflow_signals": (),
         "has_coverage_config": False,
         "top_languages": (),
-        "bazel_lockfile_ok": None,
-        "bazel_lockfile_exists": None,
+        "bazel_lockfile_status": LockfileStatus.UNKNOWN,
         "bazel_lockfile_error": None,
     }
 

--- a/src/generate_repo_overview/models.py
+++ b/src/generate_repo_overview/models.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 DEFAULT_CATEGORY = "Uncategorized"
 DEFAULT_SUBCATEGORY = "General"
-SNAPSHOT_SCHEMA_VERSION = 18
+SNAPSHOT_SCHEMA_VERSION = 21
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,6 +52,7 @@ class DeepContentSignals:
     """Deep, slow-to-collect content signals from default-branch tree inspection."""
 
     is_bazel_repo: bool = False
+    has_bazel_module: bool = False
     bazel_version: str | None = None
     codeowners: tuple[str, ...] = ()
     referenced_by_reference_integration: bool = False
@@ -64,11 +65,14 @@ class DeepContentSignals:
     has_coverage_config: bool = False
     top_languages: tuple[str, ...] = ()
     bazel_deps: tuple[tuple[str, str], ...] = ()
+    bazel_lockfile_ok: bool | None = None
+    bazel_lockfile_error: str | None = None
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> DeepContentSignals:
         return cls(
             is_bazel_repo=bool(data.get("is_bazel_repo", False)),
+            has_bazel_module=bool(data.get("has_bazel_module", False)),
             bazel_version=cast("str | None", data.get("bazel_version")),
             codeowners=normalize_string_tuple(data.get("codeowners")),
             referenced_by_reference_integration=bool(
@@ -85,6 +89,8 @@ class DeepContentSignals:
             has_coverage_config=bool(data.get("has_coverage_config", False)),
             top_languages=normalize_string_tuple(data.get("top_languages")),
             bazel_deps=normalize_string_pairs(data.get("bazel_deps")),
+            bazel_lockfile_ok=cast("bool | None", data.get("bazel_lockfile_ok")),
+            bazel_lockfile_error=cast("str | None", data.get("bazel_lockfile_error")),
         )
 
 

--- a/src/generate_repo_overview/models.py
+++ b/src/generate_repo_overview/models.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+class LockfileStatus(StrEnum):
+    OK = "ok"
+    MISSING = "missing"
+    ERROR = "error"
+    TIMEOUT = "timeout"
+    UNKNOWN = "unknown"
+
 
 DEFAULT_CATEGORY = "Uncategorized"
 DEFAULT_SUBCATEGORY = "General"
@@ -65,8 +74,7 @@ class DeepContentSignals:
     has_coverage_config: bool = False
     top_languages: tuple[str, ...] = ()
     bazel_deps: tuple[tuple[str, str], ...] = ()
-    bazel_lockfile_ok: bool | None = None
-    bazel_lockfile_exists: bool | None = None
+    bazel_lockfile_status: LockfileStatus = LockfileStatus.UNKNOWN
     bazel_lockfile_error: str | None = None
 
     @classmethod
@@ -90,8 +98,7 @@ class DeepContentSignals:
             has_coverage_config=bool(data.get("has_coverage_config", False)),
             top_languages=normalize_string_tuple(data.get("top_languages")),
             bazel_deps=normalize_string_pairs(data.get("bazel_deps")),
-            bazel_lockfile_ok=cast("bool | None", data.get("bazel_lockfile_ok")),
-            bazel_lockfile_exists=cast("bool | None", data.get("bazel_lockfile_exists")),
+            bazel_lockfile_status=_parse_lockfile_status(data.get("bazel_lockfile_status")),
             bazel_lockfile_error=cast("str | None", data.get("bazel_lockfile_error")),
         )
 
@@ -330,6 +337,15 @@ class RepoSnapshot:
 
 
 CustomPropertyValue = str | list[str] | None
+
+
+def _parse_lockfile_status(value: object) -> LockfileStatus:
+    if isinstance(value, str):
+        try:
+            return LockfileStatus(value)
+        except ValueError:
+            pass
+    return LockfileStatus.UNKNOWN
 
 
 def normalize_string_pairs(value: object) -> tuple[tuple[str, str], ...]:

--- a/src/generate_repo_overview/models.py
+++ b/src/generate_repo_overview/models.py
@@ -75,7 +75,7 @@ class DeepContentSignals:
     top_languages: tuple[str, ...] = ()
     bazel_deps: tuple[tuple[str, str], ...] = ()
     bazel_lockfile_status: LockfileStatus = LockfileStatus.UNKNOWN
-    bazel_lockfile_error: str | None = None
+    bazel_lockfile_error_output: str | None = None
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> DeepContentSignals:
@@ -99,7 +99,7 @@ class DeepContentSignals:
             top_languages=normalize_string_tuple(data.get("top_languages")),
             bazel_deps=normalize_string_pairs(data.get("bazel_deps")),
             bazel_lockfile_status=_parse_lockfile_status(data.get("bazel_lockfile_status")),
-            bazel_lockfile_error=cast("str | None", data.get("bazel_lockfile_error")),
+            bazel_lockfile_error_output=cast("str | None", data.get("bazel_lockfile_error_output")),
         )
 
 

--- a/src/generate_repo_overview/models.py
+++ b/src/generate_repo_overview/models.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 DEFAULT_CATEGORY = "Uncategorized"
 DEFAULT_SUBCATEGORY = "General"
-SNAPSHOT_SCHEMA_VERSION = 21
+SNAPSHOT_SCHEMA_VERSION = 22
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,6 +66,7 @@ class DeepContentSignals:
     top_languages: tuple[str, ...] = ()
     bazel_deps: tuple[tuple[str, str], ...] = ()
     bazel_lockfile_ok: bool | None = None
+    bazel_lockfile_exists: bool | None = None
     bazel_lockfile_error: str | None = None
 
     @classmethod
@@ -90,6 +91,7 @@ class DeepContentSignals:
             top_languages=normalize_string_tuple(data.get("top_languages")),
             bazel_deps=normalize_string_pairs(data.get("bazel_deps")),
             bazel_lockfile_ok=cast("bool | None", data.get("bazel_lockfile_ok")),
+            bazel_lockfile_exists=cast("bool | None", data.get("bazel_lockfile_exists")),
             bazel_lockfile_error=cast("str | None", data.get("bazel_lockfile_error")),
         )
 

--- a/src/generate_repo_overview/templates/styles.css
+++ b/src/generate_repo_overview/templates/styles.css
@@ -244,14 +244,6 @@ a:hover { text-decoration: underline; }
   vertical-align: text-bottom;
 }
 
-.icon-lockfile {
-  font-size: 0.85em;
-  vertical-align: text-bottom;
-}
-.icon-lockfile-fail {
-  filter: grayscale(0.3);
-  opacity: 0.8;
-}
 
 a.lockfile-error-link {
   color: inherit;

--- a/src/generate_repo_overview/templates/styles.css
+++ b/src/generate_repo_overview/templates/styles.css
@@ -244,6 +244,38 @@ a:hover { text-decoration: underline; }
   vertical-align: text-bottom;
 }
 
+.icon-lockfile {
+  font-size: 0.85em;
+  vertical-align: text-bottom;
+}
+.icon-lockfile-fail {
+  filter: grayscale(0.3);
+  opacity: 0.8;
+}
+
+a.lockfile-error-link {
+  color: inherit;
+  text-decoration: none;
+}
+a.lockfile-error-link:hover {
+  text-decoration: underline;
+}
+
+pre.lockfile-error {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--red);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  overflow-x: auto;
+  padding: 0.8rem 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .mono { font-family: var(--mono); font-size: 0.78rem; }
 .text-muted { color: var(--muted); }
 .text-right { text-align: right; }

--- a/tests/test_cli_render.py
+++ b/tests/test_cli_render.py
@@ -217,4 +217,4 @@ def test_render_details_index_links_to_detail_pages(tmp_path: Path) -> None:
     )
 
     index_content = (output_dir / "index.html").read_text(encoding="utf-8")
-    assert 'href="tools/"' in index_content
+    assert 'href="tools/index.html"' in index_content


### PR DESCRIPTION
## Why

There was no way to tell from the dashboard whether a repository's Bazel lockfile (`MODULE.bazel.lock`) exists and is up to date. Stale or missing lockfiles cause build failures that are hard to spot without checking each repo manually.

## What

For every Bazel module repository (those with `MODULE.bazel`), the collector runs `bazel mod deps --lockfile_mode=error` in a local checkout during the slow collection path (i.e. when the default branch SHA changes). The result is cached with the content signals and displayed in the Tech Stack tab as a new **Lockfile** column with four states:

| Badge | Meaning |
|---|---|
| `ok` green | Lockfile exists and is up to date |
| `missing` yellow | `MODULE.bazel.lock` does not exist — links to detail page with instructions |
| `error` red | Lockfile check failed — links to detail page showing the error output |
| `n/a` grey | Bazel module repo, not yet collected |
| `—` grey | Not a Bazel module repository |

The detail page gains a **Bazel Lockfile** section (anchored at `#lockfile-error`) that shows either the Bazel error output or a message explaining the lockfile is missing with the command to fix it.

Repo-name links are updated to point to `<repo>/index.html` instead of `<repo>/` so navigation works correctly when opened as local files.

## Changes

- `models.py` — new fields `has_bazel_module`, `bazel_lockfile_ok`, `bazel_lockfile_exists`, `bazel_lockfile_error` on `DeepContentSignals`; schema version 22
- `collector/signal_detection.py` — `detect_bazel_lockfile_ok()`: checks lockfile presence, runs `bazel mod deps --lockfile_mode=error`, returns 3-tuple `(ok, lockfile_exists, error)`
- `collector/repo_entry.py` — calls lockfile check in slow path when `has_bazel_module`; threads `github_token` through; caches all three lockfile fields
- `collector/__init__.py` — passes `github_token` to `collect_repository_entry`
- `_html_index.py` — new Lockfile column in Tech Stack tab; `_lockfile_cell()` helper; all repo links use `index.html`
- `_html_detail.py` — `_render_lockfile_error_section()` for both missing and error states
- `templates/styles.css` — `pre.lockfile-error` and `a.lockfile-error-link` styles
- `.gitignore` — ignore `.cache/repo_checkouts/`
- `tests/test_cli_render.py` — update link assertion to `index.html`