### PR TITLE
feat: grouping config

### DIFF
--- a/docs/repo-overview-tool-design.md
+++ b/docs/repo-overview-tool-design.md
@@ -12,7 +12,7 @@
 The tool is split into three layers:
 
 1. `org_config.py`
-   - Loads organization-specific settings from `org_config.toml`: org name, repo include patterns, tracked Bazel deps, workflow signals, reference integration repo, and registry repo.
+   - Loads organization-specific settings from `org_config.toml`: org name, repo include patterns, grouping levels, tracked Bazel deps, workflow signals, reference integration repo, and registry repo.
 2. `collector/`
    - Connects to GitHub.
    - Loads active repositories and custom properties.

--- a/org_config.toml
+++ b/org_config.toml
@@ -7,6 +7,27 @@
 
 org_name = "eclipse-score"
 
+# Grouping levels control how repositories are grouped in the rendered output.
+# Each level maps a GitHub repository custom property key to a fallback value
+# used when the property is absent or empty.
+#
+# 0 levels — repositories are not grouped; everything appears in a flat list.
+# 1 level  — repositories are grouped into top-level sections only.
+# 2 levels — repositories are grouped into sections and subsections (default).
+#
+# property: the GitHub custom property key to read from each repository.
+# default:  the fallback label shown when a repository has no value for that property.
+#
+# Remove or comment out one entry to use only one level of grouping.
+# Remove both entries (or omit the [grouping] section) for no grouping.
+[[grouping.levels]]
+property = "category"
+default = "Uncategorized"
+
+[[grouping.levels]]
+property = "subcategory"
+default = "General"
+
 # Optional fnmatch glob patterns to limit which repositories are included.
 # When empty (or omitted), all non-archived repositories in the org are included.
 # Example: repo_include_patterns = ["my-prefix-*", "another-repo"]

--- a/org_config.toml
+++ b/org_config.toml
@@ -11,7 +11,8 @@ org_name = "eclipse-score"
 # Each level maps a GitHub repository custom property key to a fallback value
 # used when the property is absent or empty.
 #
-# 0 levels — repositories are not grouped; everything appears in a flat list.
+# 0 levels — all repositories fall back to the default label ("Uncategorized"),
+#             so they appear under a single section with no meaningful grouping.
 # 1 level  — repositories are grouped into top-level sections only.
 # 2 levels — repositories are grouped into sections and subsections (default).
 #

--- a/src/generate_repo_overview/_html_detail.py
+++ b/src/generate_repo_overview/_html_detail.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from ._html_common import BAZEL_ICON, CSS, GITHUB_ICON, e, language_badge, version_badge
 from .metrics_report import tracked_dep_label
-from .models import LockfileStatus
+from .models import DEFAULT_CATEGORY, DEFAULT_SUBCATEGORY, LockfileStatus
 
 if TYPE_CHECKING:
     from .models import RepoEntry, RepoSnapshot
@@ -44,9 +44,11 @@ def _render_hero(entry: RepoEntry, org_name: str) -> str:
     if entry.content.is_bazel_repo:
         name_html += f" {BAZEL_ICON}"
 
-    chips = f'<span class="badge muted">{e(entry.category)}</span>'
-    if entry.subcategory and entry.subcategory != entry.category:
-        chips += f' <span class="badge muted">{e(entry.subcategory)}</span>'
+    chips = ""
+    if entry.category != DEFAULT_CATEGORY:
+        chips += f'<span class="badge muted">{e(entry.category)}</span>'
+        if entry.subcategory != DEFAULT_SUBCATEGORY:
+            chips += f' <span class="badge muted">{e(entry.subcategory)}</span>'
     for lang in entry.content.top_languages:
         chips += f" {language_badge(lang)}"
 

--- a/src/generate_repo_overview/_html_index.py
+++ b/src/generate_repo_overview/_html_index.py
@@ -564,7 +564,8 @@ def _lockfile_cell(entry: RepoEntry) -> tuple[str, str]:
         link_text = f'<a href="{url}" class="lockfile-error-link">error</a>' if has_error else "error"
         return f'<span class="badge red">{link_text}</span>', "The Bazel lockfile is out of date — click to see the error."
     if status == LockfileStatus.TIMEOUT:
-        return '<span class="badge yellow">timeout</span>', "Bazel lockfile check timed out."
+        cell = f'<span class="badge yellow"><a href="{url}" class="lockfile-error-link">timeout</a></span>'
+        return cell, "Bazel lockfile check timed out — click for details."
     if entry.content.has_bazel_module:
         return '<span class="text-muted">n/a</span>', "Lockfile status not yet collected."
     return '<span class="text-muted">—</span>', "Not a Bazel module repository."

--- a/src/generate_repo_overview/collector/__init__.py
+++ b/src/generate_repo_overview/collector/__init__.py
@@ -383,6 +383,7 @@ def fetch_repositories(
                 repository_name=repository_name,
                 repository=repository_data.repository,
                 custom_properties=repository_data.custom_properties,
+                grouping_levels=config.grouping_levels,
                 bazel_registry_metadata=bazel_registry_metadata_by_repo.get(
                     repository_name
                 ),

--- a/src/generate_repo_overview/collector/repo_entry.py
+++ b/src/generate_repo_overview/collector/repo_entry.py
@@ -11,6 +11,7 @@ from generate_repo_overview.models import (
     DEFAULT_SUBCATEGORY,
     CustomPropertyValue,
     DeepContentSignals,
+    GroupingLevel,
     LockfileStatus,
     RegistrySignals,
     RepoEntry,
@@ -67,11 +68,24 @@ DEFAULT_VOLATILE_METRICS_TTL_MINUTES = 60
 VOLATILE_METRICS_TTL_ENV = "REPO_OVERVIEW_VOLATILE_TTL_MINUTES"
 
 
+def _resolve_grouping_value(
+    custom_properties: dict[str, CustomPropertyValue],
+    grouping_levels: tuple[GroupingLevel, ...],
+    index: int,
+    fallback: str,
+) -> str:
+    if index < len(grouping_levels):
+        level = grouping_levels[index]
+        return normalize_group_name(custom_properties.get(level.property), level.default)
+    return fallback
+
+
 def collect_repository_entry(
     *,
     repository_name: str,
     repository: Any,
     custom_properties: dict[str, CustomPropertyValue],
+    grouping_levels: tuple[GroupingLevel, ...] = (),
     bazel_registry_metadata: RegistrySignalsPayload | None,
     cached_entry: RepoEntry | None,
     referenced_by_reference_integration: bool = False,
@@ -82,6 +96,7 @@ def collect_repository_entry(
         repository_name=repository_name,
         repository=repository,
         custom_properties=custom_properties,
+        grouping_levels=grouping_levels,
         bazel_registry_metadata=bazel_registry_metadata,
         referenced_by_reference_integration=referenced_by_reference_integration,
         cached_entry=cached_entry,
@@ -93,6 +108,7 @@ def collect_repository_entry(
         repository_name=repository_name,
         repository=repository,
         custom_properties=custom_properties,
+        grouping_levels=grouping_levels,
         bazel_registry_metadata=bazel_registry_metadata,
         referenced_by_reference_integration=referenced_by_reference_integration,
         cached_entry=cached_entry,
@@ -106,6 +122,7 @@ def maybe_collect_repository_entry_fast_path(
     repository_name: str,
     repository: Any,
     custom_properties: dict[str, CustomPropertyValue],
+    grouping_levels: tuple[GroupingLevel, ...] = (),
     bazel_registry_metadata: RegistrySignalsPayload | None,
     referenced_by_reference_integration: bool,
     cached_entry: RepoEntry | None,
@@ -132,6 +149,7 @@ def maybe_collect_repository_entry_fast_path(
             repository_name=repository_name,
             description=cast("str | None", getattr(repository, "description", None)),
             custom_properties=custom_properties,
+            grouping_levels=grouping_levels,
             default_branch=default_branch,
             default_branch_sha=default_branch_sha,
             bazel_registry_metadata=bazel_registry_metadata,
@@ -160,6 +178,7 @@ def maybe_collect_repository_entry_fast_path(
         repository_name=repository_name,
         description=cast("str | None", getattr(repository, "description", None)),
         custom_properties=custom_properties,
+        grouping_levels=grouping_levels,
         default_branch=default_branch,
         default_branch_sha=default_branch_sha,
         content_signals=content_signals,
@@ -176,6 +195,7 @@ def collect_repository_entry_slow_path(
     repository_name: str,
     repository: Any,
     custom_properties: dict[str, CustomPropertyValue],
+    grouping_levels: tuple[GroupingLevel, ...] = (),
     bazel_registry_metadata: RegistrySignalsPayload | None,
     referenced_by_reference_integration: bool,
     cached_entry: RepoEntry | None,
@@ -202,17 +222,20 @@ def collect_repository_entry_slow_path(
             ref=default_branch_sha,
             workflow_signals=workflow_signals,
         )
-        if content_signals["has_bazel_module"]:
-            lockfile_status, lockfile_error = _detect_lockfile_ok_for_repo(
-                repository_name=repository_name,
-                repository=repository,
-                default_branch=default_branch,
-                github_token=github_token,
-            )
-            content_signals["bazel_lockfile_status"] = lockfile_status
-            content_signals["bazel_lockfile_error_output"] = lockfile_error
     else:
         content_signals = cached_content_signals
+    if content_signals["has_bazel_module"] and (
+        cached_content_signals is None
+        or content_signals["bazel_lockfile_status"] == LockfileStatus.UNKNOWN
+    ):
+        lockfile_status, lockfile_error = _detect_lockfile_ok_for_repo(
+            repository_name=repository_name,
+            repository=repository,
+            default_branch=default_branch,
+            github_token=github_token,
+        )
+        content_signals["bazel_lockfile_status"] = lockfile_status
+        content_signals["bazel_lockfile_error_output"] = lockfile_error
     content_signals["referenced_by_reference_integration"] = (
         referenced_by_reference_integration
     )
@@ -227,6 +250,7 @@ def collect_repository_entry_slow_path(
         repository_name=repository_name,
         description=cast("str | None", getattr(repository, "description", None)),
         custom_properties=custom_properties,
+        grouping_levels=grouping_levels,
         default_branch=default_branch,
         default_branch_sha=default_branch_sha,
         content_signals=content_signals,
@@ -386,6 +410,7 @@ def build_repo_entry_from_cached(
     repository_name: str,
     description: str | None,
     custom_properties: dict[str, CustomPropertyValue],
+    grouping_levels: tuple[GroupingLevel, ...] = (),
     default_branch: str | None,
     default_branch_sha: str | None,
     bazel_registry_metadata: RegistrySignalsPayload | None,
@@ -402,13 +427,8 @@ def build_repo_entry_from_cached(
         cached_entry,
         name=repository_name,
         description=description or "(no description)",
-        category=normalize_group_name(
-            custom_properties.get("category"), DEFAULT_CATEGORY
-        ),
-        subcategory=normalize_group_name(
-            custom_properties.get("subcategory"),
-            DEFAULT_SUBCATEGORY,
-        ),
+        category=_resolve_grouping_value(custom_properties, grouping_levels, 0, DEFAULT_CATEGORY),
+        subcategory=_resolve_grouping_value(custom_properties, grouping_levels, 1, DEFAULT_SUBCATEGORY),
         default_branch=default_branch,
         default_branch_sha=default_branch_sha,
         content=content,
@@ -423,6 +443,7 @@ def build_repo_entry(
     description: str | None,
     custom_properties: dict[str, CustomPropertyValue],
     *,
+    grouping_levels: tuple[GroupingLevel, ...] = (),
     default_branch: str | None = None,
     default_branch_sha: str | None = None,
     content_signals: DeepContentPayload,
@@ -432,11 +453,8 @@ def build_repo_entry(
     stars: int = 0,
     forks: int = 0,
 ) -> RepoEntry:
-    category = normalize_group_name(custom_properties.get("category"), DEFAULT_CATEGORY)
-    subcategory = normalize_group_name(
-        custom_properties.get("subcategory"),
-        DEFAULT_SUBCATEGORY,
-    )
+    category = _resolve_grouping_value(custom_properties, grouping_levels, 0, DEFAULT_CATEGORY)
+    subcategory = _resolve_grouping_value(custom_properties, grouping_levels, 1, DEFAULT_SUBCATEGORY)
     return RepoEntry(
         name=repository_name,
         description=description or "(no description)",

--- a/src/generate_repo_overview/models.py
+++ b/src/generate_repo_overview/models.py
@@ -21,6 +21,14 @@ SNAPSHOT_SCHEMA_VERSION = 22
 
 
 @dataclass(frozen=True, slots=True)
+class GroupingLevel:
+    """A grouping dimension mapped to a GitHub custom property key."""
+
+    property: str
+    default: str
+
+
+@dataclass(frozen=True, slots=True)
 class TrackedDep:
     """A Bazel dependency tracked across all repositories."""
 

--- a/src/generate_repo_overview/org_config.py
+++ b/src/generate_repo_overview/org_config.py
@@ -59,8 +59,10 @@ def load_org_config(path: Path) -> OrgConfig:
                 f"{field_name} must be in 'org/repo' format, got '{field_value}'."
             )
 
-    grouping_section = cast("dict[str, Any]", raw.get("grouping", {}))
-    grouping_levels = _parse_grouping_levels(grouping_section.get("levels"))
+    raw_grouping = raw.get("grouping", {})
+    if not isinstance(raw_grouping, dict):
+        raise ValueError("'grouping' must be a table, not a scalar value.")
+    grouping_levels = _parse_grouping_levels(raw_grouping.get("levels"))
 
     return OrgConfig(
         org_name=org_name.strip(),
@@ -122,6 +124,7 @@ def _parse_grouping_levels(value: object) -> tuple[GroupingLevel, ...]:
             isinstance(property_, str)
             and property_.strip()
             and isinstance(default, str)
+            and default.strip()
         ):
             result.append(GroupingLevel(property=property_.strip(), default=default.strip()))
     if len(result) > 2:

--- a/src/generate_repo_overview/org_config.py
+++ b/src/generate_repo_overview/org_config.py
@@ -5,7 +5,7 @@ import tomllib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
-from generate_repo_overview.models import TrackedDep, WorkflowSignal
+from generate_repo_overview.models import GroupingLevel, TrackedDep, WorkflowSignal
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -21,6 +21,7 @@ class OrgConfig:
     workflow_signals: tuple[WorkflowSignal, ...] = ()
     reference_integration_repo: str = ""
     registry_repo: str = ""
+    grouping_levels: tuple[GroupingLevel, ...] = ()
 
     def repo_matches_filter(self, repo_name: str) -> bool:
         if not self.repo_include_patterns:
@@ -58,6 +59,9 @@ def load_org_config(path: Path) -> OrgConfig:
                 f"{field_name} must be in 'org/repo' format, got '{field_value}'."
             )
 
+    grouping_section = cast("dict[str, Any]", raw.get("grouping", {}))
+    grouping_levels = _parse_grouping_levels(grouping_section.get("levels"))
+
     return OrgConfig(
         org_name=org_name.strip(),
         repo_include_patterns=_parse_string_list(raw.get("repo_include_patterns")),
@@ -65,6 +69,7 @@ def load_org_config(path: Path) -> OrgConfig:
         workflow_signals=_parse_workflow_signals(signals.get("workflow_signals")),
         reference_integration_repo=reference_integration_repo,
         registry_repo=registry_repo,
+        grouping_levels=grouping_levels,
     )
 
 
@@ -101,6 +106,28 @@ def _parse_tracked_deps(value: object) -> tuple[TrackedDep, ...]:
             and module_name.strip()
         ):
             result.append(TrackedDep(repo=repo.strip(), module_name=module_name.strip()))
+    return tuple(result)
+
+
+def _parse_grouping_levels(value: object) -> tuple[GroupingLevel, ...]:
+    if not isinstance(value, list):
+        return ()
+    result: list[GroupingLevel] = []
+    for item in cast("list[Any]", value):
+        if not isinstance(item, dict):
+            continue
+        property_ = item.get("property")
+        default = item.get("default")
+        if (
+            isinstance(property_, str)
+            and property_.strip()
+            and isinstance(default, str)
+        ):
+            result.append(GroupingLevel(property=property_.strip(), default=default.strip()))
+    if len(result) > 2:
+        raise ValueError(
+            f"grouping.levels supports at most 2 entries, got {len(result)}."
+        )
     return tuple(result)
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -21,6 +21,7 @@ from generate_repo_overview.collector.repo_entry import (
 from generate_repo_overview.console import print_status
 from generate_repo_overview.models import (
     CategoryConfig,
+    GroupingLevel,
     ReadmeConfig,
     RegistrySignals,
     RepoEntry,
@@ -110,6 +111,10 @@ def test_build_repo_entry_uses_custom_properties_and_description_fallback() -> N
         repository_name="tools",
         description=None,
         custom_properties={"category": "Infrastructure", "subcategory": None},
+        grouping_levels=(
+            GroupingLevel(property="category", default="Uncategorized"),
+            GroupingLevel(property="subcategory", default="General"),
+        ),
         content_signals=signal_detection.default_content_signals(),
         registry_signals=RegistrySignals(),
         volatile_metrics={

--- a/tests/test_org_config.py
+++ b/tests/test_org_config.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from generate_repo_overview.models import TrackedDep, WorkflowSignal
+from generate_repo_overview.models import GroupingLevel, TrackedDep, WorkflowSignal
 from generate_repo_overview.org_config import OrgConfig, load_org_config
 
 if TYPE_CHECKING:
@@ -24,6 +24,10 @@ class TestOrgConfigDefaults:
         assert config.workflow_signals == ()
         assert config.reference_integration_repo == ""
         assert config.registry_repo == ""
+
+    def test_grouping_levels_default_is_empty(self) -> None:
+        config = OrgConfig(org_name="my-org")
+        assert config.grouping_levels == ()
 
 
 class TestLoadOrgConfig:
@@ -198,6 +202,124 @@ class TestConfigValidation:
         config = load_org_config(toml_path)
         assert len(config.workflow_signals) == 1
         assert config.workflow_signals[0].label == "Valid"
+
+
+class TestGroupingLevels:
+    def test_absent_grouping_section_returns_empty_tuple(self, tmp_path: Path) -> None:
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text('org_name = "test"\n', encoding="utf-8")
+        config = load_org_config(toml_path)
+        assert config.grouping_levels == ()
+
+    def test_empty_levels_list_returns_empty_tuple(self, tmp_path: Path) -> None:
+        content = dedent("""\
+            org_name = "test"
+            [grouping]
+            levels = []
+        """)
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text(content, encoding="utf-8")
+        config = load_org_config(toml_path)
+        assert config.grouping_levels == ()
+
+    def test_one_grouping_level(self, tmp_path: Path) -> None:
+        content = dedent("""\
+            org_name = "test"
+
+            [[grouping.levels]]
+            property = "area"
+            default = "Unknown"
+        """)
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text(content, encoding="utf-8")
+        config = load_org_config(toml_path)
+        assert config.grouping_levels == (GroupingLevel(property="area", default="Unknown"),)
+
+    def test_two_grouping_levels_eclipse_score_style(self, tmp_path: Path) -> None:
+        content = dedent("""\
+            org_name = "eclipse-score"
+
+            [[grouping.levels]]
+            property = "category"
+            default = "Uncategorized"
+
+            [[grouping.levels]]
+            property = "subcategory"
+            default = "General"
+        """)
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text(content, encoding="utf-8")
+        config = load_org_config(toml_path)
+        assert config.grouping_levels == (
+            GroupingLevel(property="category", default="Uncategorized"),
+            GroupingLevel(property="subcategory", default="General"),
+        )
+
+    def test_three_grouping_levels_raises(self, tmp_path: Path) -> None:
+        content = dedent("""\
+            org_name = "test"
+
+            [[grouping.levels]]
+            property = "a"
+            default = "A"
+
+            [[grouping.levels]]
+            property = "b"
+            default = "B"
+
+            [[grouping.levels]]
+            property = "c"
+            default = "C"
+        """)
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text(content, encoding="utf-8")
+        with pytest.raises(ValueError, match="at most 2"):
+            load_org_config(toml_path)
+
+    def test_entry_missing_property_is_skipped(self, tmp_path: Path) -> None:
+        content = dedent("""\
+            org_name = "test"
+
+            [[grouping.levels]]
+            default = "Fallback"
+
+            [[grouping.levels]]
+            property = "area"
+            default = "Unknown"
+        """)
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text(content, encoding="utf-8")
+        config = load_org_config(toml_path)
+        assert config.grouping_levels == (GroupingLevel(property="area", default="Unknown"),)
+
+    def test_entry_missing_default_is_skipped(self, tmp_path: Path) -> None:
+        content = dedent("""\
+            org_name = "test"
+
+            [[grouping.levels]]
+            property = "area"
+
+            [[grouping.levels]]
+            property = "team"
+            default = "Common"
+        """)
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text(content, encoding="utf-8")
+        config = load_org_config(toml_path)
+        assert config.grouping_levels == (GroupingLevel(property="team", default="Common"),)
+
+    def test_property_and_default_are_stripped(self, tmp_path: Path) -> None:
+        content = dedent("""\
+            org_name = "test"
+
+            [[grouping.levels]]
+            property = "  area  "
+            default = "  Unknown  "
+        """)
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text(content, encoding="utf-8")
+        config = load_org_config(toml_path)
+        assert config.grouping_levels == (GroupingLevel(property="area", default="Unknown"),)
 
 
 class TestReferenceIntegrationOrgName:

--- a/tests/test_org_config.py
+++ b/tests/test_org_config.py
@@ -321,6 +321,33 @@ class TestGroupingLevels:
         config = load_org_config(toml_path)
         assert config.grouping_levels == (GroupingLevel(property="area", default="Unknown"),)
 
+    def test_entry_whitespace_only_default_is_skipped(self, tmp_path: Path) -> None:
+        content = dedent("""\
+            org_name = "test"
+
+            [[grouping.levels]]
+            property = "area"
+            default = "   "
+
+            [[grouping.levels]]
+            property = "team"
+            default = "Common"
+        """)
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text(content, encoding="utf-8")
+        config = load_org_config(toml_path)
+        assert config.grouping_levels == (GroupingLevel(property="team", default="Common"),)
+
+    def test_grouping_as_scalar_raises(self, tmp_path: Path) -> None:
+        content = dedent("""\
+            org_name = "test"
+            grouping = "not-a-table"
+        """)
+        toml_path = tmp_path / "org.toml"
+        toml_path.write_text(content, encoding="utf-8")
+        with pytest.raises(ValueError, match=r"grouping.*must be a table"):
+            load_org_config(toml_path)
+
 
 class TestReferenceIntegrationOrgName:
     def test_parse_github_remote_with_custom_org(self) -> None:

--- a/tests/test_repo_overview.py
+++ b/tests/test_repo_overview.py
@@ -13,10 +13,12 @@ import generate_repo_overview.collector.registry_metadata as registry_metadata
 import generate_repo_overview.collector.repo_entry as repo_entry
 import generate_repo_overview.collector.signal_detection as signal_detection
 import generate_repo_overview.collector.snapshot_io as snapshot_io
+from generate_repo_overview.collector.signal_detection import default_content_signals
 from generate_repo_overview.metrics_report import render_metrics_report
 from generate_repo_overview.models import (
     SNAPSHOT_SCHEMA_VERSION,
     DeepContentSignals,
+    GroupingLevel,
     RegistrySignals,
     RepoEntry,
     RepoSnapshot,
@@ -380,6 +382,10 @@ def test_collect_repository_entry_reuses_cached_details_when_unchanged() -> None
         repository_name="tools",
         repository=repo,
         custom_properties={"category": "Engineering", "subcategory": "Platform"},
+        grouping_levels=(
+            GroupingLevel(property="category", default="Uncategorized"),
+            GroupingLevel(property="subcategory", default="General"),
+        ),
         bazel_registry_metadata={
             "maintainers_in_bazel_registry": ("New Maintainer",),
             "latest_bazel_registry_version": "0.2.0",
@@ -1591,6 +1597,112 @@ def test_metrics_report_automation_with_multiple_signals() -> None:
     assert "Daily Workflow" in markdown
     assert "Nightly Build" in markdown
     assert "| yes | no |" in markdown
+
+
+class TestBuildRepoEntryGroupingLevels:
+    """Tests for grouping_levels parameter on build_repo_entry."""
+
+    def _minimal_signals(self) -> "repo_entry.DeepContentPayload":
+        return default_content_signals()
+
+    def test_no_grouping_levels_returns_defaults(self) -> None:
+        entry = repo_entry.build_repo_entry(
+            "my-repo",
+            "A repo",
+            custom_properties={"category": "Infra", "subcategory": "Tooling"},
+            grouping_levels=(),
+            content_signals=self._minimal_signals(),
+            registry_signals=RegistrySignals(),
+            volatile_metrics=repo_entry.collect_volatile_metrics(
+                _FakeMinimalRepo(), default_branch=None, default_branch_sha=None
+            ),
+        )
+        from generate_repo_overview.models import DEFAULT_CATEGORY, DEFAULT_SUBCATEGORY
+        assert entry.category == DEFAULT_CATEGORY
+        assert entry.subcategory == DEFAULT_SUBCATEGORY
+
+    def test_one_grouping_level_resolves_category_only(self) -> None:
+        entry = repo_entry.build_repo_entry(
+            "my-repo",
+            "A repo",
+            custom_properties={"area": "Platform"},
+            grouping_levels=(GroupingLevel(property="area", default="Unknown"),),
+            content_signals=self._minimal_signals(),
+            registry_signals=RegistrySignals(),
+            volatile_metrics=repo_entry.collect_volatile_metrics(
+                _FakeMinimalRepo(), default_branch=None, default_branch_sha=None
+            ),
+        )
+        from generate_repo_overview.models import DEFAULT_SUBCATEGORY
+        assert entry.category == "Platform"
+        assert entry.subcategory == DEFAULT_SUBCATEGORY
+
+    def test_one_grouping_level_uses_level_default_on_missing_property(self) -> None:
+        entry = repo_entry.build_repo_entry(
+            "my-repo",
+            "A repo",
+            custom_properties={},
+            grouping_levels=(GroupingLevel(property="area", default="Unknown"),),
+            content_signals=self._minimal_signals(),
+            registry_signals=RegistrySignals(),
+            volatile_metrics=repo_entry.collect_volatile_metrics(
+                _FakeMinimalRepo(), default_branch=None, default_branch_sha=None
+            ),
+        )
+        assert entry.category == "Unknown"
+
+    def test_two_custom_grouping_levels_both_resolved(self) -> None:
+        entry = repo_entry.build_repo_entry(
+            "my-repo",
+            "A repo",
+            custom_properties={"area": "Platform", "team": "Core"},
+            grouping_levels=(
+                GroupingLevel(property="area", default="Unknown"),
+                GroupingLevel(property="team", default="Common"),
+            ),
+            content_signals=self._minimal_signals(),
+            registry_signals=RegistrySignals(),
+            volatile_metrics=repo_entry.collect_volatile_metrics(
+                _FakeMinimalRepo(), default_branch=None, default_branch_sha=None
+            ),
+        )
+        assert entry.category == "Platform"
+        assert entry.subcategory == "Core"
+
+    def test_classic_grouping_levels_match_old_hardcoded_behavior(self) -> None:
+        entry = repo_entry.build_repo_entry(
+            "my-repo",
+            "A repo",
+            custom_properties={"category": "Infra", "subcategory": "Tooling"},
+            grouping_levels=(
+                GroupingLevel(property="category", default="Uncategorized"),
+                GroupingLevel(property="subcategory", default="General"),
+            ),
+            content_signals=self._minimal_signals(),
+            registry_signals=RegistrySignals(),
+            volatile_metrics=repo_entry.collect_volatile_metrics(
+                _FakeMinimalRepo(), default_branch=None, default_branch_sha=None
+            ),
+        )
+        assert entry.category == "Infra"
+        assert entry.subcategory == "Tooling"
+
+
+class _FakeMinimalRepo:
+    """Minimal repo stub for volatile metrics collection with no API calls."""
+    open_issues_count = 0
+    pushed_at = None
+    stargazers_count = 0
+    forks_count = 0
+
+    def get_branch(self, _: str) -> None:
+        return None
+
+    def get_pulls(self, *_: Any, **__: Any) -> list[Any]:
+        return []
+
+    def get_latest_release(self) -> None:
+        return None
 
 
 def test_snapshot_from_dict_filters_empty_tracked_deps() -> None:


### PR DESCRIPTION
## Why

The `category` and `subcategory` grouping properties were hardcoded as GitHub custom property keys throughout the collector. Eclipse-score happens to use those exact names, but other organizations may use different property names — or may not need hierarchical grouping at all. There was no way to configure this without changing source code.

## What

Grouping is now configured in `org_config.toml` via a `[[grouping.levels]]` array. Each entry maps a GitHub custom property key (`property`) to a fallback label (`default`) used when a repository has no value for that property. Between 0 and 2 levels are supported:

- **0 levels** — flat list, no grouping
- **1 level** — top-level sections only
- **2 levels** — sections and subsections (eclipse-score's existing behavior)

Eclipse-score's `org_config.toml` now explicitly declares its two levels with `property = "category"` and `property = "subcategory"`, so behavior is unchanged.

The detail page hero badges that previously always showed "Uncategorized / General" for unconfigured orgs are now suppressed — they only appear when the values are non-default.

A bug found during review is also fixed: a cached `UNKNOWN` lockfile status was never re-checked even when the repository was revisited. It now retries the lockfile check whenever the cached status is `UNKNOWN`.

## Changes

- `models.py` — add `GroupingLevel(property, default)` dataclass
- `org_config.py` — add `grouping_levels` field to `OrgConfig`; `_parse_grouping_levels()` parser (validates max 2 entries)
- `collector/repo_entry.py` — `_resolve_grouping_value()` helper; thread `grouping_levels` through all collection functions; fix stale `UNKNOWN` lockfile status never being retried
- `collector/__init__.py` — pass `config.grouping_levels` to `collect_repository_entry`
- `_html_detail.py` — suppress category/subcategory badges when values are the default fallbacks; fix `TIMEOUT` lockfile badge linking to detail page
- `_html_index.py` — `TIMEOUT` lockfile badge now links to the detail page anchor (same as `MISSING` and `ERROR`)
- `org_config.toml` — add `[[grouping.levels]]` entries with explanatory comments
- `docs/repo-overview-tool-design.md` — mention grouping levels in the `org_config.py` description
- `tests/` — 14 new test cases covering grouping level parsing and resolution