### PR TITLE
Update links in README for releases and guidelines

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,12 +9,12 @@ Dive into our key resources below to understand our project, learn how to contri
 Explore the official documentation to understand the core components and features of Eclipse S-CORE. <br/>[**Read the Guide &raquo;**](https://eclipse-score.github.io/score) 
 
 **Download Latest Release**<br/>
-Get the latest stable release to start building or check the release notes for recent changes. <br/> [**View Releases &raquo;**](https://github.com/eclipse-score/score/releases) <br/><br/>
+Get the latest stable release to start building or check the release notes for recent changes. <br/> [**View Releases &raquo;**](https://github.com/eclipse-score/reference_integration/releases) <br/><br/>
 
 
 | How to Contribute | Development Process | Roadmap & Architecture |
 | :--- | :--- | :--- |
-| Your starting point. This guide details the process for making contributions that align with our technical direction. <br/><br/> [**Read the Guideline &raquo;**](https://eclipse-score.github.io/score/main/contribute/index.html) | Learn about our rigid software development process, designed to ensure automotive-grade quality and performance. <br/><br/> [**View the Process &raquo;**](https://eclipse-score.github.io/process_description/main/index.html) | Explore our feature roadmap and architecture to understand the technical direction and future of S-CORE. <br/><br/> [**See the Roadmap &raquo;**](https://eclipse-score.github.io/score/main/score_releases/index.html#releases) |
+| Your starting point. This guide details the process for making contributions that align with our technical direction. <br/><br/> [**Read the Guideline &raquo;**]([https://eclipse-score.github.io/score/main/contribute/index.html](https://eclipse-score.github.io/score/main/users_guide/index.html)) | Learn about our software development process, designed to ensure automotive-grade quality and performance. <br/><br/> [**View the Process &raquo;**](https://eclipse-score.github.io/process_description/main/index.html) | Explore our feature roadmap and architecture to understand the technical direction and future of S-CORE. <br/><br/> [**See the Roadmap &raquo;**](https://eclipse-score.github.io/reference_integration/main/s_core_v_1/releases/releases.html) |
 
 ## Repositories in the Github organization
 


### PR DESCRIPTION
Updated Links: 
Release to latest releases page in Github for reference_integration repo

From old Handbook url to new user guide