### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,16 +1,17 @@
 # Security Policy
+
 This Eclipse Foundation Project adheres to the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).
 
 ## How To Report a Vulnerability
 
 If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
 
-**Please do not report security vulnerabilities through public issues, discussions, or pull requests.**
+**Please do not report security vulnerabilities through public issues, discussions, or change requests.**
 
 Instead, report it using one of the following ways:
 
-* Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org) via email
 * Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+* Report a [vulnerability](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/report-privately) directly via private vulnerability reporting on GitHub
 
 You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
 


### PR DESCRIPTION
Eclipse Foundation has updated the secutity policy; therefore, we need to update it in S-CORE.

See https://www.eclipse.org/lists/eclipse.org-committers/msg01582.html

I modified the link for Github vulnerability reporting to point to the official how-to page, because this generic SECURITY.md gets applied to all S-CORE repositories, and the private reporting work per repository only.