### PR TITLE
fix: handle repositories without a default branch

### DIFF
--- a/docs/repo-overview/collection-and-cache.md
+++ b/docs/repo-overview/collection-and-cache.md
@@ -56,10 +56,12 @@ Authentication is passed through a transient Git HTTP header and is not written
 into the remote URL.
 
 For a repository without any commits, GitHub may report a default-branch name
-even though the Git remote has no references. A failed branch checkout is
-therefore followed by an authenticated `ls-remote` check. A reachable remote
-without references is collected as an empty repository with neutral content
-signals; transport errors and non-empty checkout failures remain errors.
+even though that branch cannot be resolved. After a failed checkout, the
+collector checks the default branch through the GitHub API before falling back
+to an authenticated `ls-remote` check. A missing default branch, or a reachable
+remote without references, is collected as an empty repository with neutral
+content signals; transport errors and non-empty checkout failures remain
+errors.
 
 ## Schema Changes
 

--- a/src/generate_repo_overview/collector/repo_entry.py
+++ b/src/generate_repo_overview/collector/repo_entry.py
@@ -323,6 +323,15 @@ def _sync_content_checkout(
         checkout_path=checkout_path,
     )
     if synced is None:
+        # GitHub can expose a repository's configured default-branch name even
+        # after that branch has never been created.  In that case a remote may
+        # still have unrelated refs (for example a tag), so ls-remote alone is
+        # not sufficient to identify an empty repository.
+        if (
+            hasattr(repository, "get_branch")
+            and get_default_branch_sha(repository, default_branch) is None
+        ):
+            return (None, None)
         if (
             remote_repository_has_refs(
                 clone_url,

--- a/tests/test_repo_overview.py
+++ b/tests/test_repo_overview.py
@@ -32,6 +32,15 @@ from generate_repo_overview.models import (
 from generate_repo_overview.org_config import OrgConfig
 
 
+def _run_git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_snapshot_round_trip_preserves_repository_overview(tmp_path: Path) -> None:
     snapshot = RepoSnapshot(
         schema_version=SNAPSHOT_SCHEMA_VERSION,
@@ -511,6 +520,66 @@ def test_collect_repository_entry_accepts_repository_without_commits(
     assert entry.default_branch_sha is None
     assert entry.content == DeepContentSignals()
     assert entry.volatile.last_push_date is None
+
+
+def test_collect_repository_entry_accepts_repository_without_default_branch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(source)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _run_git(source, "config", "user.name", "Test User")
+    _run_git(source, "config", "user.email", "test@example.com")
+    (source / "README.md").write_text("reserved\n", encoding="utf-8")
+    _run_git(source, "add", "README.md")
+    _run_git(source, "commit", "-m", "initial")
+    _run_git(source, "tag", "v0.0.0")
+    _run_git(source, "update-ref", "-d", "refs/heads/main")
+
+    class RepositoryWithoutDefaultBranch:
+        clone_url = str(source)
+        default_branch = "main"
+        description = "Reserved repository"
+        forks_count = 0
+        full_name = "eclipse-score/empty-no-default-branch"
+        open_issues_count = 0
+        pushed_at = None
+        stargazers_count = 0
+
+        def get_branch(self, branch_name: str) -> object:
+            raise RuntimeError(f"Branch {branch_name} does not exist")
+
+        def get_languages(self) -> dict[str, int]:
+            return {}
+
+        def get_latest_release(self) -> object:
+            raise RuntimeError("No releases")
+
+        def get_pulls(self, **_: Any) -> list[object]:
+            return []
+
+    monkeypatch.setattr(
+        repo_entry,
+        "DEFAULT_REPOSITORY_CHECKOUTS",
+        tmp_path / "checkouts",
+    )
+
+    entry = repo_entry.collect_repository_entry(
+        repository_name="empty-no-default-branch",
+        repository=RepositoryWithoutDefaultBranch(),
+        custom_properties={},
+        bazel_registry_metadata=None,
+        cached_entry=None,
+    )
+
+    assert entry.default_branch == "main"
+    assert entry.default_branch_sha is None
+    assert entry.content == DeepContentSignals()
 
 
 def test_collect_repository_entry_does_not_reuse_cached_registry_when_metadata_missing() -> (


### PR DESCRIPTION
## Summary
- treat repositories without a resolvable default branch as empty
- avoid false synchronization failures when unrelated refs remain
- add regression coverage and update collection documentation

## Tests
- `uv run pytest -q`
- `uv run ruff check src/ tests/`
- `uv run basedpyright src/` (0 errors; existing warnings only)