### PR TITLE
Fix platform documentation association across repository categories

### DIFF
--- a/src/generate_repo_overview/collector/__init__.py
+++ b/src/generate_repo_overview/collector/__init__.py
@@ -252,8 +252,6 @@ def enrich_repositories_with_platform_docs(
                 sphinx_modules=(),
             ),
         )
-        if entry.category.casefold() == "modules"
-        else entry
         for entry in repos
     ]
     for full_name in platform_repos:

--- a/src/generate_repo_overview/collector/platform_docs.py
+++ b/src/generate_repo_overview/collector/platform_docs.py
@@ -41,9 +41,8 @@ def enrich_repositories_from_platform_docs(
         tree_paths=tree_paths,
         source_repo=source_repo,
     )
-    module_repos = [entry for entry in repos if entry.category.casefold() == "modules"]
-    features_by_repo = associate_sphinx_items(features, module_repos)
-    modules_by_repo = associate_sphinx_items(modules, module_repos)
+    features_by_repo = associate_sphinx_items(features, repos)
+    modules_by_repo = associate_sphinx_items(modules, repos)
 
     return [
         replace(
@@ -60,8 +59,6 @@ def enrich_repositories_from_platform_docs(
                 ),
             ),
         )
-        if entry.category.casefold() == "modules"
-        else entry
         for entry in repos
     ]
 

--- a/tests/test_platform_docs.py
+++ b/tests/test_platform_docs.py
@@ -163,6 +163,40 @@ def test_enrichment_keeps_same_feature_from_public_and_private_sources(
     )
 
 
+def test_enrichment_associates_platform_docs_without_modules_category(
+    tmp_path: Path,
+) -> None:
+    contents = {
+        "docs/features/logging/architecture/index.rst": (
+            ".. feat:: Logging\n   :id: feat__logging\n"
+        ),
+    }
+    _write_contents(tmp_path, contents)
+
+    repo = RepoEntry(
+        name="logging",
+        description="logging",
+        category="COM",
+        subcategory="General",
+        content=DeepContentSignals(bazel_module_name="score_logging"),
+    )
+
+    enriched = enrich_repositories_from_platform_docs(
+        [repo],
+        checkout_path=tmp_path,
+        source_repo="eclipse-score/score",
+    )
+
+    assert enriched[0].content.sphinx_features == (
+        SphinxItem(
+            path="docs/features/logging",
+            title="Logging",
+            identifier="feat__logging",
+            source_repo="eclipse-score/score",
+        ),
+    )
+
+
 def test_association_skips_ambiguous_matches() -> None:
     item = SphinxItem(
         path="docs/features/logging",


### PR DESCRIPTION
## Summary

- Associate platform feature and module declarations with repositories regardless of their category label.
- Reset and enrich platform metadata consistently for every repository.
- Add regression coverage for a repository using a non-`modules` category.

## Motivation

The collector currently restricts platform-documentation association to entries whose category is exactly `modules`. Organizations may use custom category values, causing valid declarations to be discovered but discarded. The existing match threshold and ambiguity margin remain in place, so removing the category coupling preserves the safeguards against weak or ambiguous matches.
